### PR TITLE
Implement stopping behavior

### DIFF
--- a/OpenUtauMobile/ViewModels/EditViewModel.cs
+++ b/OpenUtauMobile/ViewModels/EditViewModel.cs
@@ -185,6 +185,8 @@ namespace OpenUtauMobile.ViewModels
         [Reactive] public string Path { get; set; } = string.Empty;
         [Reactive] public ObservableCollectionExtended<UTrack> Tracks { get; set; } = [];
         //[Reactive] public ObservableCollectionExtended<UPart> Parts { get; set; } = [];
+        [Reactive] public int PlaybackStartPosition { get; set; } = 0;
+        [Reactive] public bool PlaybackWasStoppedManually { get; set; } = true;
         [Reactive] public int PlayPosTick { get; set; } = 0;
         [Reactive] public bool Playing { get; set; } = false;
         [Reactive] public byte[] CurrentPortrait { get; set; } = [];


### PR DESCRIPTION
This PR adds a two-stage stop behavior:

1. First stop press:
    Returns playback to the beginning of the current playback segment (similar to “return to start” in many DAWs).

2. Second stop press (consecutive):
    Moves playback to the absolute start of the project (tick 0).