### PR TITLE
Add a phoneme and parameter panel and add translations

### DIFF
--- a/OpenUtau.Core/Ustx/UExpression.cs
+++ b/OpenUtau.Core/Ustx/UExpression.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Linq;
 using YamlDotNet.Serialization;
@@ -25,6 +25,9 @@ namespace OpenUtau.Core.Ustx {
         public string flag;
         public string[] options;
         public bool skipOutputIfDefault = false;
+        [YamlIgnore] public string Name => name;
+        [YamlIgnore] public string Abbr => abbr;
+        [YamlIgnore] public string DisplayName => string.IsNullOrWhiteSpace(abbr) ? (name ?? string.Empty) : abbr.ToUpperInvariant();
         [YamlIgnore]
         public float CustomDefaultValue {
             get => _customDefaultValue ?? defaultValue;

--- a/OpenUtau.Core/Ustx/UExpression.cs
+++ b/OpenUtau.Core/Ustx/UExpression.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Linq;
 using YamlDotNet.Serialization;
@@ -25,9 +25,6 @@ namespace OpenUtau.Core.Ustx {
         public string flag;
         public string[] options;
         public bool skipOutputIfDefault = false;
-        [YamlIgnore] public string Name => name;
-        [YamlIgnore] public string Abbr => abbr;
-        [YamlIgnore] public string DisplayName => string.IsNullOrWhiteSpace(abbr) ? (name ?? string.Empty) : abbr.ToUpperInvariant();
         [YamlIgnore]
         public float CustomDefaultValue {
             get => _customDefaultValue ?? defaultValue;

--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -320,6 +320,22 @@ errors.txt
             /// 是否显示全局性能监视悬浮层。
             /// </summary>
             public bool PerformanceMonitorEnabled = false;
+            /// <summary>
+            /// 音素与参数面板高度（像素）。
+            /// </summary>
+            public double PhonemePanelHeight = 128;
+            /// <summary>
+            /// 音素与参数面板编辑模式：0=Simple, 1=Advanced, 2=Draw, 3=Erase。
+            /// </summary>
+            public int PhonemePanelMode = 0;
+            /// <summary>
+            /// 参数面板主编辑参数缩写。
+            /// </summary>
+            public string PrimaryExpressionKey = "vel";
+            /// <summary>
+            /// 参数面板背景参数缩写。
+            /// </summary>
+            public string SecondaryExpressionKey = string.Empty;
             #endregion
         }
     }

--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -320,22 +320,6 @@ errors.txt
             /// 是否显示全局性能监视悬浮层。
             /// </summary>
             public bool PerformanceMonitorEnabled = false;
-            /// <summary>
-            /// 音素与参数面板高度（像素）。
-            /// </summary>
-            public double PhonemePanelHeight = 128;
-            /// <summary>
-            /// 音素与参数面板编辑模式：0=Simple, 1=Advanced, 2=Draw, 3=Erase。
-            /// </summary>
-            public int PhonemePanelMode = 0;
-            /// <summary>
-            /// 参数面板主编辑参数缩写。
-            /// </summary>
-            public string PrimaryExpressionKey = "vel";
-            /// <summary>
-            /// 参数面板背景参数缩写。
-            /// </summary>
-            public string SecondaryExpressionKey = string.Empty;
             #endregion
         }
     }

--- a/OpenUtauMobile/Assets/Lang/Strings.en.resx
+++ b/OpenUtauMobile/Assets/Lang/Strings.en.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -1648,4 +1648,58 @@
   <data name="PerformanceMonitor.AppShort" xml:space="preserve"><value>App</value></data>
   <data name="PerformanceMonitor.SystemShort" xml:space="preserve"><value>System</value></data>
   <data name="PerformanceMonitor.Fps" xml:space="preserve"><value>FPS</value></data>
+  <data name="PhonemePanel.EditMode.Switch" xml:space="preserve">
+    <value>Switch phoneme &amp; parameter edit mode</value>
+  </data>
+  <data name="PhonemePanel.Mode.Simple" xml:space="preserve">
+    <value>Simple phoneme mode</value>
+  </data>
+  <data name="PhonemePanel.Mode.Advanced" xml:space="preserve">
+    <value>Advanced phoneme mode</value>
+  </data>
+  <data name="PhonemePanel.Mode.Draw" xml:space="preserve">
+    <value>Parameter draw mode</value>
+  </data>
+  <data name="PhonemePanel.Mode.Erase" xml:space="preserve">
+    <value>Parameter erase mode</value>
+  </data>
+  <data name="PhonemePanel.Toast.Simple" xml:space="preserve">
+    <value>Simple phoneme mode</value>
+  </data>
+  <data name="PhonemePanel.Toast.Advanced" xml:space="preserve">
+    <value>Advanced phoneme mode</value>
+  </data>
+  <data name="PhonemePanel.Toast.Draw" xml:space="preserve">
+    <value>Parameter draw mode</value>
+  </data>
+  <data name="PhonemePanel.Toast.Erase" xml:space="preserve">
+    <value>Parameter erase mode</value>
+  </data>
+  <data name="PhonemePanel.Param.Primary" xml:space="preserve">
+    <value>Primary parameter</value>
+  </data>
+  <data name="PhonemePanel.Param.Secondary" xml:space="preserve">
+    <value>Background parameter</value>
+  </data>
+  <data name="PhonemePanel.Param.Swap" xml:space="preserve">
+    <value>Swap primary &amp; background parameters</value>
+  </data>
+  <data name="PhonemePanel.Param.None" xml:space="preserve">
+    <value>None</value>
+  </data>
+  <data name="PhonemePanel.Split.Tooltip" xml:space="preserve">
+    <value>Drag to resize phoneme/parameter panel</value>
+  </data>
+  <data name="PhonemeEdit.Title" xml:space="preserve">
+    <value>Edit Phoneme Alias</value>
+  </data>
+  <data name="PhonemeEdit.Watermark" xml:space="preserve">
+    <value>Default alias (leave empty for auto)</value>
+  </data>
+  <data name="PhonemeEdit.Reset" xml:space="preserve">
+    <value>Reset</value>
+  </data>
+  <data name="PhonemeEdit.Info" xml:space="preserve">
+    <value>Note: {0} | Phoneme #{1}</value>
+  </data>
 </root>

--- a/OpenUtauMobile/Assets/Lang/Strings.ja.resx
+++ b/OpenUtauMobile/Assets/Lang/Strings.ja.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -1641,4 +1641,58 @@
   <data name="PerformanceMonitor.AppShort" xml:space="preserve"><value>アプリ</value></data>
   <data name="PerformanceMonitor.SystemShort" xml:space="preserve"><value>システム</value></data>
   <data name="PerformanceMonitor.Fps" xml:space="preserve"><value>FPS</value></data>
+  <data name="PhonemePanel.EditMode.Switch" xml:space="preserve">
+    <value>音素・パラメータ編集モードの切替</value>
+  </data>
+  <data name="PhonemePanel.Mode.Simple" xml:space="preserve">
+    <value>シンプル音素モード</value>
+  </data>
+  <data name="PhonemePanel.Mode.Advanced" xml:space="preserve">
+    <value>詳細音素モード</value>
+  </data>
+  <data name="PhonemePanel.Mode.Draw" xml:space="preserve">
+    <value>パラメータ描画モード</value>
+  </data>
+  <data name="PhonemePanel.Mode.Erase" xml:space="preserve">
+    <value>パラメータ消しゴムモード</value>
+  </data>
+  <data name="PhonemePanel.Toast.Simple" xml:space="preserve">
+    <value>シンプル音素モード</value>
+  </data>
+  <data name="PhonemePanel.Toast.Advanced" xml:space="preserve">
+    <value>詳細音素モード</value>
+  </data>
+  <data name="PhonemePanel.Toast.Draw" xml:space="preserve">
+    <value>パラメータ描画モード</value>
+  </data>
+  <data name="PhonemePanel.Toast.Erase" xml:space="preserve">
+    <value>パラメータ消しゴムモード</value>
+  </data>
+  <data name="PhonemePanel.Param.Primary" xml:space="preserve">
+    <value>主パラメータ</value>
+  </data>
+  <data name="PhonemePanel.Param.Secondary" xml:space="preserve">
+    <value>背景パラメータ</value>
+  </data>
+  <data name="PhonemePanel.Param.Swap" xml:space="preserve">
+    <value>主/背景パラメータの入れ替え</value>
+  </data>
+  <data name="PhonemePanel.Param.None" xml:space="preserve">
+    <value>なし</value>
+  </data>
+  <data name="PhonemePanel.Split.Tooltip" xml:space="preserve">
+    <value>ドラッグしてパネル高さを調整</value>
+  </data>
+  <data name="PhonemeEdit.Title" xml:space="preserve">
+    <value>音素エイリアスの編集</value>
+  </data>
+  <data name="PhonemeEdit.Watermark" xml:space="preserve">
+    <value>デフォルト（空欄で自動）</value>
+  </data>
+  <data name="PhonemeEdit.Reset" xml:space="preserve">
+    <value>初期化</value>
+  </data>
+  <data name="PhonemeEdit.Info" xml:space="preserve">
+    <value>ノート: {0} | 音素 #{1}</value>
+  </data>
 </root>

--- a/OpenUtauMobile/Assets/Lang/Strings.ru.resx
+++ b/OpenUtauMobile/Assets/Lang/Strings.ru.resx
@@ -1,110 +1,51 @@
-<?xml version="1.0" encoding="utf-8"?>
-<root>
-  <!-- 
-    Microsoft ResX Schema 
-    
-    Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
-    associated with the data types.
-    
-    Example:
-    
-    ... ado.net/XML headers & schema ...
-    <resheader name="resmimetype">text/microsoft-resx</resheader>
-    <resheader name="version">2.0</resheader>
-    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-        <value>[base64 mime encoded serialized .NET Framework object]</value>
-    </data>
-    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
-        <comment>This is a comment</comment>
-    </data>
-                
-    There are any number of "resheader" rows that contain simple 
-    name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
-    mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
-    extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
-    read any of the formats listed below.
-    
-    mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
-            : and then encoded with base64 encoding.
-    
-    mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-            : and then encoded with base64 encoding.
-
-    mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
-            : using a System.ComponentModel.TypeConverter
-            : and then encoded with base64 encoding.
-    -->
-  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
-    <xsd:element name="root" msdata:IsDataSet="true">
-      <xsd:complexType>
-        <xsd:choice maxOccurs="unbounded">
-          <xsd:element name="metadata">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" />
-              </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string" />
-              <xsd:attribute name="type" type="xsd:string" />
-              <xsd:attribute name="mimetype" type="xsd:string" />
-              <xsd:attribute ref="xml:space" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="assembly">
-            <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string" />
-              <xsd:attribute name="name" type="xsd:string" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="data">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-              </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-              <xsd:attribute ref="xml:space" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="resheader">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-              </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" />
-            </xsd:complexType>
-          </xsd:element>
-        </xsd:choice>
-      </xsd:complexType>
-    </xsd:element>
-  </xsd:schema>
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:schema id="root">
+    <xs:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xs:element name="root" ns1:IsDataSet="true">
+      <xs:complexType>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element name="metadata">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" />
+              </xs:sequence>
+              <xs:attribute name="name" use="required" type="xsd:string" />
+              <xs:attribute name="type" type="xsd:string" />
+              <xs:attribute name="mimetype" type="xsd:string" />
+              <xs:attribute ref="xml:space" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="assembly">
+            <xs:complexType>
+              <xs:attribute name="alias" type="xsd:string" />
+              <xs:attribute name="name" type="xsd:string" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="data">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+                <xs:element name="comment" type="xsd:string" minOccurs="0" ns1:Ordinal="2" />
+              </xs:sequence>
+              <xs:attribute name="name" type="xsd:string" use="required" ns1:Ordinal="1" />
+              <xs:attribute name="type" type="xsd:string" ns1:Ordinal="3" />
+              <xs:attribute name="mimetype" type="xsd:string" ns1:Ordinal="4" />
+              <xs:attribute ref="xml:space" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="resheader">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+              </xs:sequence>
+              <xs:attribute name="name" type="xsd:string" use="required" />
+            </xs:complexType>
+          </xs:element>
+        </xs:choice>
+      </xs:complexType>
+    </xs:element>
+  </xs:schema>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
@@ -1438,25 +1379,25 @@
     <value>Готово</value>
   </data>
   <data name="BatchEdit.Title" xml:space="preserve">
-    <value>Batch edit</value>
+    <value>Пакетное редактирование</value>
   </data>
   <data name="BatchEdit.Tab.Lyrics" xml:space="preserve">
-    <value>Lyrics</value>
+    <value>Текст</value>
   </data>
   <data name="BatchEdit.Tab.Notes" xml:space="preserve">
-    <value>Notes</value>
+    <value>Ноты</value>
   </data>
   <data name="BatchEdit.Tab.Reset" xml:space="preserve">
-    <value>Reset</value>
+    <value>Сброс</value>
   </data>
   <data name="BatchEdit.Scope.Selected" xml:space="preserve">
-    <value>{0} selected notes</value>
+    <value>Выбранные ноты ({0})</value>
   </data>
   <data name="BatchEdit.Scope.Part" xml:space="preserve">
-    <value>All {0} notes in the current part</value>
+    <value>Все ноты текущей партии ({0})</value>
   </data>
   <data name="BatchEdit.Run" xml:space="preserve">
-    <value>Run</value>
+    <value>Выполнить</value>
   </data>
   <data name="BatchEdit.Pin" xml:space="preserve">
     <value>Закрепить</value>
@@ -1468,201 +1409,252 @@
     <value>Закреплённые</value>
   </data>
   <data name="BatchEdit.Confirm" xml:space="preserve">
-    <value>Confirm</value>
+    <value>Подтвердить</value>
   </data>
   <data name="BatchEdit.Parameter.Lyric" xml:space="preserve">
-    <value>Lyric</value>
+    <value>Текст</value>
   </data>
   <data name="BatchEdit.Parameter.Semitones" xml:space="preserve">
-    <value>Semitones</value>
+    <value>Полутоны</value>
   </data>
   <data name="BatchEdit.Parameter.Ticks" xml:space="preserve">
-    <value>Ticks</value>
+    <value>Тики</value>
   </data>
   <data name="BatchEdit.Parameter.Ratio" xml:space="preserve">
-    <value>Ratio (0–1)</value>
+    <value>Коэффициент (0–1)</value>
   </data>
   <data name="BatchEdit.Parameter.Cents" xml:space="preserve">
-    <value>Maximum cents</value>
+    <value>Макс. центы</value>
   </data>
   <data name="BatchEdit.Validation.Required" xml:space="preserve">
-    <value>Enter a value.</value>
+    <value>Введите значение.</value>
   </data>
   <data name="BatchEdit.Validation.Number" xml:space="preserve">
-    <value>Enter a valid number in the allowed range.</value>
+    <value>Введите корректное число в допустимом диапазоне.</value>
   </data>
   <data name="BatchEdit.Validation.Confirm" xml:space="preserve">
-    <value>This operation changes or resets note data. Select Confirm to continue.</value>
+    <value>Эта операция изменяет или сбрасывает данные нот. Нажмите «Подтвердить» для продолжения.</value>
   </data>
   <data name="BatchEdit.Status.Running" xml:space="preserve">
-    <value>Running {0}…</value>
+    <value>Выполнение «{0}»…</value>
   </data>
   <data name="BatchEdit.Status.Progress" xml:space="preserve">
     <value>{0} / {1}</value>
   </data>
   <data name="BatchEdit.Status.Completed" xml:space="preserve">
-    <value>Completed {0}.</value>
+    <value>Действие «{0}» завершено.</value>
   </data>
   <data name="BatchEdit.Status.Cancelled" xml:space="preserve">
-    <value>Operation cancelled.</value>
+    <value>Операция отменена.</value>
   </data>
   <data name="BatchEdit.Status.Failed" xml:space="preserve">
-    <value>{0} failed.</value>
+    <value>Ошибка выполнения «{0}».</value>
   </data>
   <data name="BatchEdit.Action.RomajiToHiragana" xml:space="preserve">
-    <value>Romaji to Hiragana</value>
+    <value>Ромадзи в хирагану</value>
   </data>
   <data name="BatchEdit.Action.HiraganaToRomaji" xml:space="preserve">
-    <value>Hiragana to Romaji</value>
+    <value>Хирагана в ромадзи</value>
   </data>
   <data name="BatchEdit.Action.JapaneseVcvToCv" xml:space="preserve">
-    <value>Japanese VCV to CV</value>
+    <value>Японский VCV в CV</value>
   </data>
   <data name="BatchEdit.Action.RemoveToneSuffix" xml:space="preserve">
-    <value>Remove tone suffix</value>
+    <value>Удалить суффикс тона</value>
   </data>
   <data name="BatchEdit.Action.RemoveLetterSuffix" xml:space="preserve">
-    <value>Remove letter suffix</value>
+    <value>Удалить буквенный суффикс</value>
   </data>
   <data name="BatchEdit.Action.MoveSuffixToVoiceColor" xml:space="preserve">
-    <value>Move suffix to voice color</value>
+    <value>Перенести суффикс в тембр (Voice Color)</value>
   </data>
   <data name="BatchEdit.Action.RemovePhoneticHint" xml:space="preserve">
-    <value>Remove phonetic hint</value>
+    <value>Удалить фонетическую подсказку</value>
   </data>
   <data name="BatchEdit.Action.DashToPlus" xml:space="preserve">
-    <value>Convert dash to plus</value>
+    <value>Заменить тире на плюс</value>
   </data>
   <data name="BatchEdit.Action.DashToPlusTilde" xml:space="preserve">
-    <value>Convert dash to plus-tilde</value>
+    <value>Заменить тире на плюс-тильду</value>
   </data>
   <data name="BatchEdit.Action.InsertSlur" xml:space="preserve">
-    <value>Insert slur</value>
+    <value>Вставить легато (Slur)</value>
   </data>
   <data name="BatchEdit.Action.AddTailNote" xml:space="preserve">
-    <value>Add tail note</value>
+    <value>Добавить хвостовую ноту</value>
   </data>
   <data name="BatchEdit.Action.RemoveTailNote" xml:space="preserve">
-    <value>Remove tail note</value>
+    <value>Удалить хвостовую ноту</value>
   </data>
   <data name="BatchEdit.Action.AddBreathNote" xml:space="preserve">
-    <value>Add breath note</value>
+    <value>Добавить ноту дыхания</value>
   </data>
   <data name="BatchEdit.Action.Transpose" xml:space="preserve">
-    <value>Transpose</value>
+    <value>Транспонировать</value>
   </data>
   <data name="BatchEdit.Action.Quantize" xml:space="preserve">
-    <value>Quantize notes</value>
+    <value>Квантование нот</value>
   </data>
   <data name="BatchEdit.Action.AutoLegato" xml:space="preserve">
-    <value>Auto legato</value>
+    <value>Авто-легато</value>
   </data>
   <data name="BatchEdit.Action.FixOverlap" xml:space="preserve">
-    <value>Fix overlapping notes</value>
+    <value>Исправить перекрытия нот</value>
   </data>
   <data name="BatchEdit.Action.CommonNoteCopy" xml:space="preserve">
-    <value>Copy as CommonNote</value>
+    <value>Копировать как CommonNote</value>
   </data>
   <data name="BatchEdit.Action.CommonNotePaste" xml:space="preserve">
-    <value>Paste CommonNote</value>
+    <value>Вставить CommonNote</value>
   </data>
   <data name="BatchEdit.Action.HanziToPinyin" xml:space="preserve">
-    <value>Hanzi to Pinyin</value>
+    <value>Иероглифы (Ханьцзы) в пиньинь</value>
   </data>
   <data name="BatchEdit.Action.LengthenCrossfade" xml:space="preserve">
-    <value>Lengthen crossfade</value>
+    <value>Увеличить кроссфейд</value>
   </data>
   <data name="BatchEdit.Action.RandomizeTiming" xml:space="preserve">
-    <value>Randomize timing</value>
+    <value>Случайный сдвиг времени</value>
   </data>
   <data name="BatchEdit.Action.RandomizePhonemeOffset" xml:space="preserve">
-    <value>Randomize phoneme offset</value>
+    <value>Случайный сдвиг фонем</value>
   </data>
   <data name="BatchEdit.Action.RandomizeTuning" xml:space="preserve">
-    <value>Randomize tuning</value>
+    <value>Случайный питч (расстройка)</value>
   </data>
   <data name="BatchEdit.Action.LoadRenderedPitch" xml:space="preserve">
-    <value>Load rendered pitch</value>
+    <value>Загрузить отрендеренный питч</value>
   </data>
   <data name="BatchEdit.Action.BakePitch" xml:space="preserve">
-    <value>Bake pitch</value>
+    <value>Запечь питч</value>
   </data>
   <data name="BatchEdit.Action.RefreshRealCurves" xml:space="preserve">
-    <value>Refresh rendered curves</value>
+    <value>Обновить отрендеренные кривые</value>
   </data>
   <data name="BatchEdit.Action.ResetPitchBends" xml:space="preserve">
-    <value>Reset pitch bends</value>
+    <value>Сбросить бенды высоты тона</value>
   </data>
   <data name="BatchEdit.Action.ResetExpressions" xml:space="preserve">
-    <value>Reset expressions</value>
+    <value>Сбросить выражения</value>
   </data>
   <data name="BatchEdit.Action.ClearVibratos" xml:space="preserve">
-    <value>Clear vibratos</value>
+    <value>Очистить вибрато</value>
   </data>
   <data name="BatchEdit.Action.ResetVibratos" xml:space="preserve">
-    <value>Reset vibratos</value>
+    <value>Сбросить вибрато</value>
   </data>
   <data name="BatchEdit.Action.ClearTimings" xml:space="preserve">
-    <value>Clear phoneme timings</value>
+    <value>Очистить тайминги фонем</value>
   </data>
   <data name="BatchEdit.Action.ResetAliases" xml:space="preserve">
-    <value>Reset phoneme aliases</value>
+    <value>Сбросить алиасы фонем</value>
   </data>
   <data name="BatchEdit.Action.ResetAll" xml:space="preserve">
-    <value>Reset all note data</value>
+    <value>Сбросить все данные нот</value>
   </data>
   <data name="BatchEdit.Validation.SelectionUnavailable" xml:space="preserve">
-    <value>The selected notes are no longer in the current part.</value>
+    <value>Выбранные ноты больше не находятся в текущей партии.</value>
   </data>
-  <data name="Settings.Render.PerformanceMonitor" xml:space="preserve"><value>Монитор производительности</value></data>
-  <data name="Settings.Render.PerformanceMonitor.Desc" xml:space="preserve"><value>Отображать использование ресурсов в реальном времени в правом верхнем углу.</value></data>
-  <data name="PerformanceMonitor.AppMemory" xml:space="preserve"><value>Память приложения</value></data>
-  <data name="PerformanceMonitor.ManagedHeap" xml:space="preserve"><value>Управляемая куча</value></data>
-  <data name="PerformanceMonitor.SystemMemory" xml:space="preserve"><value>Системная память</value></data>
-  <data name="PerformanceMonitor.Cpu" xml:space="preserve"><value>ЦП</value></data>
-  <data name="PerformanceMonitor.AppShort" xml:space="preserve"><value>Прил.</value></data>
-  <data name="PerformanceMonitor.SystemShort" xml:space="preserve"><value>Система</value></data>
-  <data name="PerformanceMonitor.Fps" xml:space="preserve"><value>FPS</value></data>
+  <data name="Settings.Render.PerformanceMonitor" xml:space="preserve">
+    <value>Монитор производительности</value>
+  </data>
+  <data name="Settings.Render.PerformanceMonitor.Desc" xml:space="preserve">
+    <value>Отображать использование ресурсов в реальном времени в правом верхнем углу.</value>
+  </data>
+  <data name="PerformanceMonitor.AppMemory" xml:space="preserve">
+    <value>Память приложения</value>
+  </data>
+  <data name="PerformanceMonitor.ManagedHeap" xml:space="preserve">
+    <value>Управляемая куча</value>
+  </data>
+  <data name="PerformanceMonitor.SystemMemory" xml:space="preserve">
+    <value>Системная память</value>
+  </data>
+  <data name="PerformanceMonitor.Cpu" xml:space="preserve">
+    <value>ЦП</value>
+  </data>
+  <data name="PerformanceMonitor.AppShort" xml:space="preserve">
+    <value>Прил.</value>
+  </data>
+  <data name="PerformanceMonitor.SystemShort" xml:space="preserve">
+    <value>Система</value>
+  </data>
+  <data name="PerformanceMonitor.Fps" xml:space="preserve">
+    <value>FPS (кадров/с)</value>
+  </data>
   <data name="PhonemePanel.EditMode.Switch" xml:space="preserve">
-    <value>Switch phoneme &amp; parameter edit mode</value>
+    <value>Переключить режим редактирования фонем и параметров</value>
   </data>
   <data name="PhonemePanel.Mode.Simple" xml:space="preserve">
-    <value>Simple phoneme mode</value>
+    <value>Простой режим фонем</value>
   </data>
   <data name="PhonemePanel.Mode.Advanced" xml:space="preserve">
-    <value>Advanced phoneme mode</value>
+    <value>Продвинутый режим фонем</value>
   </data>
   <data name="PhonemePanel.Mode.Draw" xml:space="preserve">
-    <value>Parameter draw mode</value>
+    <value>Режим рисования параметров</value>
   </data>
   <data name="PhonemePanel.Mode.Erase" xml:space="preserve">
-    <value>Parameter erase mode</value>
+    <value>Режим ластика параметров</value>
   </data>
   <data name="PhonemePanel.Toast.Simple" xml:space="preserve">
-    <value>Switched to simple phoneme mode</value>
+    <value>Переключено в простой режим фонем</value>
   </data>
   <data name="PhonemePanel.Toast.Advanced" xml:space="preserve">
-    <value>Switched to advanced phoneme mode</value>
+    <value>Переключено в продвинутый режим фонем</value>
   </data>
   <data name="PhonemePanel.Toast.Draw" xml:space="preserve">
-    <value>Switched to parameter draw mode</value>
+    <value>Переключено в режим рисования параметров</value>
   </data>
   <data name="PhonemePanel.Toast.Erase" xml:space="preserve">
-    <value>Switched to parameter erase mode</value>
+    <value>Переключено в режим ластика параметров</value>
   </data>
   <data name="PhonemePanel.Param.Primary" xml:space="preserve">
-    <value>Primary parameter</value>
+    <value>Основной параметр</value>
   </data>
   <data name="PhonemePanel.Param.Secondary" xml:space="preserve">
-    <value>Background parameter</value>
+    <value>Фоновый параметр</value>
   </data>
   <data name="PhonemePanel.Param.Swap" xml:space="preserve">
-    <value>Swap primary &amp; background parameters</value>
+    <value>Поменять местами основной и фоновый параметры</value>
   </data>
   <data name="PhonemePanel.Param.None" xml:space="preserve">
-    <value>None</value>
+    <value>Нет</value>
   </data>
   <data name="PhonemePanel.Split.Tooltip" xml:space="preserve">
-    <value>Drag to resize phoneme/parameter panel</value>
+    <value>Потяните, чтобы изменить размер панели фонем и параметров</value>
+  </data>
+  <data name="PhonemeEdit.Title" xml:space="preserve">
+    <value>Изменить алиас фонемы</value>
+  </data>
+  <data name="PhonemeEdit.Watermark" xml:space="preserve">
+    <value>Алиас по умолчанию (оставьте пустым для авто)</value>
+  </data>
+  <data name="PhonemeEdit.Reset" xml:space="preserve">
+    <value>Сбросить</value>
+  </data>
+  <data name="PhonemeEdit.Info" xml:space="preserve">
+    <value>Нота: {0} | Фонема #{1}</value>
+  </data>
+  <data name="Settings.Appearance.Theme.System" xml:space="preserve">
+    <value>Как в системе</value>
+  </data>
+  <data name="Settings.Appearance.Theme.Light" xml:space="preserve">
+    <value>Светлая</value>
+  </data>
+  <data name="Settings.Appearance.Theme.Dark" xml:space="preserve">
+    <value>Тёмная</value>
+  </data>
+  <data name="Settings.Appearance.ThemeColor" xml:space="preserve">
+    <value>Цвет темы</value>
+  </data>
+  <data name="Home.Recovery.OpenAction" xml:space="preserve">
+    <value>Открыть</value>
+  </data>
+  <data name="Home.Recovery.Dismiss" xml:space="preserve">
+    <value>Закрыть</value>
+  </data>
+  <data name="Editor.Action.Merge" xml:space="preserve">
+    <value>Объединить</value>
   </data>
 </root>

--- a/OpenUtauMobile/Assets/Lang/Strings.ru.resx
+++ b/OpenUtauMobile/Assets/Lang/Strings.ru.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -1623,4 +1623,46 @@
   <data name="PerformanceMonitor.AppShort" xml:space="preserve"><value>Прил.</value></data>
   <data name="PerformanceMonitor.SystemShort" xml:space="preserve"><value>Система</value></data>
   <data name="PerformanceMonitor.Fps" xml:space="preserve"><value>FPS</value></data>
+  <data name="PhonemePanel.EditMode.Switch" xml:space="preserve">
+    <value>Switch phoneme &amp; parameter edit mode</value>
+  </data>
+  <data name="PhonemePanel.Mode.Simple" xml:space="preserve">
+    <value>Simple phoneme mode</value>
+  </data>
+  <data name="PhonemePanel.Mode.Advanced" xml:space="preserve">
+    <value>Advanced phoneme mode</value>
+  </data>
+  <data name="PhonemePanel.Mode.Draw" xml:space="preserve">
+    <value>Parameter draw mode</value>
+  </data>
+  <data name="PhonemePanel.Mode.Erase" xml:space="preserve">
+    <value>Parameter erase mode</value>
+  </data>
+  <data name="PhonemePanel.Toast.Simple" xml:space="preserve">
+    <value>Switched to simple phoneme mode</value>
+  </data>
+  <data name="PhonemePanel.Toast.Advanced" xml:space="preserve">
+    <value>Switched to advanced phoneme mode</value>
+  </data>
+  <data name="PhonemePanel.Toast.Draw" xml:space="preserve">
+    <value>Switched to parameter draw mode</value>
+  </data>
+  <data name="PhonemePanel.Toast.Erase" xml:space="preserve">
+    <value>Switched to parameter erase mode</value>
+  </data>
+  <data name="PhonemePanel.Param.Primary" xml:space="preserve">
+    <value>Primary parameter</value>
+  </data>
+  <data name="PhonemePanel.Param.Secondary" xml:space="preserve">
+    <value>Background parameter</value>
+  </data>
+  <data name="PhonemePanel.Param.Swap" xml:space="preserve">
+    <value>Swap primary &amp; background parameters</value>
+  </data>
+  <data name="PhonemePanel.Param.None" xml:space="preserve">
+    <value>None</value>
+  </data>
+  <data name="PhonemePanel.Split.Tooltip" xml:space="preserve">
+    <value>Drag to resize phoneme/parameter panel</value>
+  </data>
 </root>

--- a/OpenUtauMobile/Assets/Lang/Strings.uk.resx
+++ b/OpenUtauMobile/Assets/Lang/Strings.uk.resx
@@ -1,110 +1,51 @@
-<?xml version="1.0" encoding="utf-8"?>
-<root>
-  <!-- 
-    Microsoft ResX Schema 
-    
-    Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
-    associated with the data types.
-    
-    Example:
-    
-    ... ado.net/XML headers & schema ...
-    <resheader name="resmimetype">text/microsoft-resx</resheader>
-    <resheader name="version">2.0</resheader>
-    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-        <value>[base64 mime encoded serialized .NET Framework object]</value>
-    </data>
-    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
-        <comment>This is a comment</comment>
-    </data>
-                
-    There are any number of "resheader" rows that contain simple 
-    name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
-    mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
-    extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
-    read any of the formats listed below.
-    
-    mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
-            : and then encoded with base64 encoding.
-    
-    mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-            : and then encoded with base64 encoding.
-
-    mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
-            : using a System.ComponentModel.TypeConverter
-            : and then encoded with base64 encoding.
-    -->
-  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
-    <xsd:element name="root" msdata:IsDataSet="true">
-      <xsd:complexType>
-        <xsd:choice maxOccurs="unbounded">
-          <xsd:element name="metadata">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" />
-              </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string" />
-              <xsd:attribute name="type" type="xsd:string" />
-              <xsd:attribute name="mimetype" type="xsd:string" />
-              <xsd:attribute ref="xml:space" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="assembly">
-            <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string" />
-              <xsd:attribute name="name" type="xsd:string" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="data">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-              </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-              <xsd:attribute ref="xml:space" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="resheader">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-              </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" />
-            </xsd:complexType>
-          </xsd:element>
-        </xsd:choice>
-      </xsd:complexType>
-    </xsd:element>
-  </xsd:schema>
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:schema id="root">
+    <xs:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xs:element name="root" ns1:IsDataSet="true">
+      <xs:complexType>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element name="metadata">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" />
+              </xs:sequence>
+              <xs:attribute name="name" use="required" type="xsd:string" />
+              <xs:attribute name="type" type="xsd:string" />
+              <xs:attribute name="mimetype" type="xsd:string" />
+              <xs:attribute ref="xml:space" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="assembly">
+            <xs:complexType>
+              <xs:attribute name="alias" type="xsd:string" />
+              <xs:attribute name="name" type="xsd:string" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="data">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+                <xs:element name="comment" type="xsd:string" minOccurs="0" ns1:Ordinal="2" />
+              </xs:sequence>
+              <xs:attribute name="name" type="xsd:string" use="required" ns1:Ordinal="1" />
+              <xs:attribute name="type" type="xsd:string" ns1:Ordinal="3" />
+              <xs:attribute name="mimetype" type="xsd:string" ns1:Ordinal="4" />
+              <xs:attribute ref="xml:space" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="resheader">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+              </xs:sequence>
+              <xs:attribute name="name" type="xsd:string" use="required" />
+            </xs:complexType>
+          </xs:element>
+        </xs:choice>
+      </xs:complexType>
+    </xs:element>
+  </xs:schema>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
@@ -1438,25 +1379,25 @@
     <value>Готово</value>
   </data>
   <data name="BatchEdit.Title" xml:space="preserve">
-    <value>Batch edit</value>
+    <value>Пакетне редагування</value>
   </data>
   <data name="BatchEdit.Tab.Lyrics" xml:space="preserve">
-    <value>Lyrics</value>
+    <value>Текст</value>
   </data>
   <data name="BatchEdit.Tab.Notes" xml:space="preserve">
-    <value>Notes</value>
+    <value>Ноти</value>
   </data>
   <data name="BatchEdit.Tab.Reset" xml:space="preserve">
-    <value>Reset</value>
+    <value>Скидання</value>
   </data>
   <data name="BatchEdit.Scope.Selected" xml:space="preserve">
-    <value>{0} selected notes</value>
+    <value>Вибрані ноти ({0})</value>
   </data>
   <data name="BatchEdit.Scope.Part" xml:space="preserve">
-    <value>All {0} notes in the current part</value>
+    <value>Усі ноти поточної партії ({0})</value>
   </data>
   <data name="BatchEdit.Run" xml:space="preserve">
-    <value>Run</value>
+    <value>Виконати</value>
   </data>
   <data name="BatchEdit.Pin" xml:space="preserve">
     <value>Закріпити</value>
@@ -1468,201 +1409,252 @@
     <value>Закріплені</value>
   </data>
   <data name="BatchEdit.Confirm" xml:space="preserve">
-    <value>Confirm</value>
+    <value>Підтвердити</value>
   </data>
   <data name="BatchEdit.Parameter.Lyric" xml:space="preserve">
-    <value>Lyric</value>
+    <value>Текст</value>
   </data>
   <data name="BatchEdit.Parameter.Semitones" xml:space="preserve">
-    <value>Semitones</value>
+    <value>Півтони</value>
   </data>
   <data name="BatchEdit.Parameter.Ticks" xml:space="preserve">
-    <value>Ticks</value>
+    <value>Тіки</value>
   </data>
   <data name="BatchEdit.Parameter.Ratio" xml:space="preserve">
-    <value>Ratio (0–1)</value>
+    <value>Коефіцієнт (0–1)</value>
   </data>
   <data name="BatchEdit.Parameter.Cents" xml:space="preserve">
-    <value>Maximum cents</value>
+    <value>Макс. центи</value>
   </data>
   <data name="BatchEdit.Validation.Required" xml:space="preserve">
-    <value>Enter a value.</value>
+    <value>Введіть значення.</value>
   </data>
   <data name="BatchEdit.Validation.Number" xml:space="preserve">
-    <value>Enter a valid number in the allowed range.</value>
+    <value>Введіть коректне число в допустимому діапазоні.</value>
   </data>
   <data name="BatchEdit.Validation.Confirm" xml:space="preserve">
-    <value>This operation changes or resets note data. Select Confirm to continue.</value>
+    <value>Ця операція змінює або скидає дані нот. Натисніть «Підтвердити» для продовження.</value>
   </data>
   <data name="BatchEdit.Status.Running" xml:space="preserve">
-    <value>Running {0}…</value>
+    <value>Виконання «{0}»…</value>
   </data>
   <data name="BatchEdit.Status.Progress" xml:space="preserve">
     <value>{0} / {1}</value>
   </data>
   <data name="BatchEdit.Status.Completed" xml:space="preserve">
-    <value>Completed {0}.</value>
+    <value>Дію «{0}» завершено.</value>
   </data>
   <data name="BatchEdit.Status.Cancelled" xml:space="preserve">
-    <value>Operation cancelled.</value>
+    <value>Операцію скасовано.</value>
   </data>
   <data name="BatchEdit.Status.Failed" xml:space="preserve">
-    <value>{0} failed.</value>
+    <value>Помилка виконання «{0}».</value>
   </data>
   <data name="BatchEdit.Action.RomajiToHiragana" xml:space="preserve">
-    <value>Romaji to Hiragana</value>
+    <value>Ромадзі в хіраґану</value>
   </data>
   <data name="BatchEdit.Action.HiraganaToRomaji" xml:space="preserve">
-    <value>Hiragana to Romaji</value>
+    <value>Хіраґана в ромадзі</value>
   </data>
   <data name="BatchEdit.Action.JapaneseVcvToCv" xml:space="preserve">
-    <value>Japanese VCV to CV</value>
+    <value>Японський VCV в CV</value>
   </data>
   <data name="BatchEdit.Action.RemoveToneSuffix" xml:space="preserve">
-    <value>Remove tone suffix</value>
+    <value>Видалити суфікс тону</value>
   </data>
   <data name="BatchEdit.Action.RemoveLetterSuffix" xml:space="preserve">
-    <value>Remove letter suffix</value>
+    <value>Видалити буквений суфікс</value>
   </data>
   <data name="BatchEdit.Action.MoveSuffixToVoiceColor" xml:space="preserve">
-    <value>Move suffix to voice color</value>
+    <value>Перенести суфікс у тембр (Voice Color)</value>
   </data>
   <data name="BatchEdit.Action.RemovePhoneticHint" xml:space="preserve">
-    <value>Remove phonetic hint</value>
+    <value>Видалити фонетичну підказку</value>
   </data>
   <data name="BatchEdit.Action.DashToPlus" xml:space="preserve">
-    <value>Convert dash to plus</value>
+    <value>Замінити тире на плюс</value>
   </data>
   <data name="BatchEdit.Action.DashToPlusTilde" xml:space="preserve">
-    <value>Convert dash to plus-tilde</value>
+    <value>Замінити тире на плюс-тільду</value>
   </data>
   <data name="BatchEdit.Action.InsertSlur" xml:space="preserve">
-    <value>Insert slur</value>
+    <value>Вставити легато (Slur)</value>
   </data>
   <data name="BatchEdit.Action.AddTailNote" xml:space="preserve">
-    <value>Add tail note</value>
+    <value>Додати хвостову ноту</value>
   </data>
   <data name="BatchEdit.Action.RemoveTailNote" xml:space="preserve">
-    <value>Remove tail note</value>
+    <value>Видалити хвостову ноту</value>
   </data>
   <data name="BatchEdit.Action.AddBreathNote" xml:space="preserve">
-    <value>Add breath note</value>
+    <value>Додати ноту дихання</value>
   </data>
   <data name="BatchEdit.Action.Transpose" xml:space="preserve">
-    <value>Transpose</value>
+    <value>Транспонувати</value>
   </data>
   <data name="BatchEdit.Action.Quantize" xml:space="preserve">
-    <value>Quantize notes</value>
+    <value>Квантування нот</value>
   </data>
   <data name="BatchEdit.Action.AutoLegato" xml:space="preserve">
-    <value>Auto legato</value>
+    <value>Авто-легато</value>
   </data>
   <data name="BatchEdit.Action.FixOverlap" xml:space="preserve">
-    <value>Fix overlapping notes</value>
+    <value>Виправити перекриття нот</value>
   </data>
   <data name="BatchEdit.Action.CommonNoteCopy" xml:space="preserve">
-    <value>Copy as CommonNote</value>
+    <value>Копіювати як CommonNote</value>
   </data>
   <data name="BatchEdit.Action.CommonNotePaste" xml:space="preserve">
-    <value>Paste CommonNote</value>
+    <value>Вставити CommonNote</value>
   </data>
   <data name="BatchEdit.Action.HanziToPinyin" xml:space="preserve">
-    <value>Hanzi to Pinyin</value>
+    <value>Ієрогліфи (Ханьцзи) в піньїнь</value>
   </data>
   <data name="BatchEdit.Action.LengthenCrossfade" xml:space="preserve">
-    <value>Lengthen crossfade</value>
+    <value>Збільшити кросфейд</value>
   </data>
   <data name="BatchEdit.Action.RandomizeTiming" xml:space="preserve">
-    <value>Randomize timing</value>
+    <value>Випадковий зсув часу</value>
   </data>
   <data name="BatchEdit.Action.RandomizePhonemeOffset" xml:space="preserve">
-    <value>Randomize phoneme offset</value>
+    <value>Випадковий зсув фонем</value>
   </data>
   <data name="BatchEdit.Action.RandomizeTuning" xml:space="preserve">
-    <value>Randomize tuning</value>
+    <value>Випадковий пітч (розстроювання)</value>
   </data>
   <data name="BatchEdit.Action.LoadRenderedPitch" xml:space="preserve">
-    <value>Load rendered pitch</value>
+    <value>Завантажити відрендерений пітч</value>
   </data>
   <data name="BatchEdit.Action.BakePitch" xml:space="preserve">
-    <value>Bake pitch</value>
+    <value>Запекти пітч</value>
   </data>
   <data name="BatchEdit.Action.RefreshRealCurves" xml:space="preserve">
-    <value>Refresh rendered curves</value>
+    <value>Оновити відрендерені криві</value>
   </data>
   <data name="BatchEdit.Action.ResetPitchBends" xml:space="preserve">
-    <value>Reset pitch bends</value>
+    <value>Скинути бенди висоти тону</value>
   </data>
   <data name="BatchEdit.Action.ResetExpressions" xml:space="preserve">
-    <value>Reset expressions</value>
+    <value>Скинути вирази</value>
   </data>
   <data name="BatchEdit.Action.ClearVibratos" xml:space="preserve">
-    <value>Clear vibratos</value>
+    <value>Очистити вібрато</value>
   </data>
   <data name="BatchEdit.Action.ResetVibratos" xml:space="preserve">
-    <value>Reset vibratos</value>
+    <value>Скинути вібрато</value>
   </data>
   <data name="BatchEdit.Action.ClearTimings" xml:space="preserve">
-    <value>Clear phoneme timings</value>
+    <value>Очистити таймінги фонем</value>
   </data>
   <data name="BatchEdit.Action.ResetAliases" xml:space="preserve">
-    <value>Reset phoneme aliases</value>
+    <value>Скинути аліаси фонем</value>
   </data>
   <data name="BatchEdit.Action.ResetAll" xml:space="preserve">
-    <value>Reset all note data</value>
+    <value>Скинути всі дані нот</value>
   </data>
   <data name="BatchEdit.Validation.SelectionUnavailable" xml:space="preserve">
-    <value>The selected notes are no longer in the current part.</value>
+    <value>Вибрані ноти більше не знаходяться в поточній партії.</value>
   </data>
-  <data name="Settings.Render.PerformanceMonitor" xml:space="preserve"><value>Монітор продуктивності</value></data>
-  <data name="Settings.Render.PerformanceMonitor.Desc" xml:space="preserve"><value>Відображати використання ресурсів у режимі реального часу у верхньому правому куті.</value></data>
-  <data name="PerformanceMonitor.AppMemory" xml:space="preserve"><value>Пам’ять застосунку</value></data>
-  <data name="PerformanceMonitor.ManagedHeap" xml:space="preserve"><value>Керована купа</value></data>
-  <data name="PerformanceMonitor.SystemMemory" xml:space="preserve"><value>Системна пам’ять</value></data>
-  <data name="PerformanceMonitor.Cpu" xml:space="preserve"><value>ЦП</value></data>
-  <data name="PerformanceMonitor.AppShort" xml:space="preserve"><value>Заст.</value></data>
-  <data name="PerformanceMonitor.SystemShort" xml:space="preserve"><value>Система</value></data>
-  <data name="PerformanceMonitor.Fps" xml:space="preserve"><value>FPS</value></data>
+  <data name="Settings.Render.PerformanceMonitor" xml:space="preserve">
+    <value>Монітор продуктивності</value>
+  </data>
+  <data name="Settings.Render.PerformanceMonitor.Desc" xml:space="preserve">
+    <value>Відображати використання ресурсів у режимі реального часу у верхньому правому куті.</value>
+  </data>
+  <data name="PerformanceMonitor.AppMemory" xml:space="preserve">
+    <value>Пам’ять застосунку</value>
+  </data>
+  <data name="PerformanceMonitor.ManagedHeap" xml:space="preserve">
+    <value>Керована купа</value>
+  </data>
+  <data name="PerformanceMonitor.SystemMemory" xml:space="preserve">
+    <value>Системна пам’ять</value>
+  </data>
+  <data name="PerformanceMonitor.Cpu" xml:space="preserve">
+    <value>ЦП</value>
+  </data>
+  <data name="PerformanceMonitor.AppShort" xml:space="preserve">
+    <value>Заст.</value>
+  </data>
+  <data name="PerformanceMonitor.SystemShort" xml:space="preserve">
+    <value>Система</value>
+  </data>
+  <data name="PerformanceMonitor.Fps" xml:space="preserve">
+    <value>FPS (кадрів/с)</value>
+  </data>
   <data name="PhonemePanel.EditMode.Switch" xml:space="preserve">
-    <value>Switch phoneme &amp; parameter edit mode</value>
+    <value>Перемкнути режим редагування фонем і параметрів</value>
   </data>
   <data name="PhonemePanel.Mode.Simple" xml:space="preserve">
-    <value>Simple phoneme mode</value>
+    <value>Простий режим фонем</value>
   </data>
   <data name="PhonemePanel.Mode.Advanced" xml:space="preserve">
-    <value>Advanced phoneme mode</value>
+    <value>Розширений режим фонем</value>
   </data>
   <data name="PhonemePanel.Mode.Draw" xml:space="preserve">
-    <value>Parameter draw mode</value>
+    <value>Режим малювання параметрів</value>
   </data>
   <data name="PhonemePanel.Mode.Erase" xml:space="preserve">
-    <value>Parameter erase mode</value>
+    <value>Режим гумки параметрів</value>
   </data>
   <data name="PhonemePanel.Toast.Simple" xml:space="preserve">
-    <value>Switched to simple phoneme mode</value>
+    <value>Перемкнуто в простий режим фонем</value>
   </data>
   <data name="PhonemePanel.Toast.Advanced" xml:space="preserve">
-    <value>Switched to advanced phoneme mode</value>
+    <value>Перемкнуто в розширений режим фонем</value>
   </data>
   <data name="PhonemePanel.Toast.Draw" xml:space="preserve">
-    <value>Switched to parameter draw mode</value>
+    <value>Перемкнуто в режим малювання параметрів</value>
   </data>
   <data name="PhonemePanel.Toast.Erase" xml:space="preserve">
-    <value>Switched to parameter erase mode</value>
+    <value>Перемкнуто в режим гумки параметрів</value>
   </data>
   <data name="PhonemePanel.Param.Primary" xml:space="preserve">
-    <value>Primary parameter</value>
+    <value>Основний параметр</value>
   </data>
   <data name="PhonemePanel.Param.Secondary" xml:space="preserve">
-    <value>Background parameter</value>
+    <value>Фоновий параметр</value>
   </data>
   <data name="PhonemePanel.Param.Swap" xml:space="preserve">
-    <value>Swap primary &amp; background parameters</value>
+    <value>Поміняти місцями основний і фоновий параметри</value>
   </data>
   <data name="PhonemePanel.Param.None" xml:space="preserve">
-    <value>None</value>
+    <value>Немає</value>
   </data>
   <data name="PhonemePanel.Split.Tooltip" xml:space="preserve">
-    <value>Drag to resize phoneme/parameter panel</value>
+    <value>Потягніть, щоб змінити розмір панелі фонем і параметрів</value>
+  </data>
+  <data name="PhonemeEdit.Title" xml:space="preserve">
+    <value>Редагувати аліас фонеми</value>
+  </data>
+  <data name="PhonemeEdit.Watermark" xml:space="preserve">
+    <value>Аліас за замовчуванням (залиште порожнім для авто)</value>
+  </data>
+  <data name="PhonemeEdit.Reset" xml:space="preserve">
+    <value>Скинути</value>
+  </data>
+  <data name="PhonemeEdit.Info" xml:space="preserve">
+    <value>Нота: {0} | Фонема #{1}</value>
+  </data>
+  <data name="Settings.Appearance.Theme.System" xml:space="preserve">
+    <value>Як у системі</value>
+  </data>
+  <data name="Settings.Appearance.Theme.Light" xml:space="preserve">
+    <value>Світла</value>
+  </data>
+  <data name="Settings.Appearance.Theme.Dark" xml:space="preserve">
+    <value>Темна</value>
+  </data>
+  <data name="Settings.Appearance.ThemeColor" xml:space="preserve">
+    <value>Колір теми</value>
+  </data>
+  <data name="Home.Recovery.OpenAction" xml:space="preserve">
+    <value>Відкрити</value>
+  </data>
+  <data name="Home.Recovery.Dismiss" xml:space="preserve">
+    <value>Закрити</value>
+  </data>
+  <data name="Editor.Action.Merge" xml:space="preserve">
+    <value>Об'єднати</value>
   </data>
 </root>

--- a/OpenUtauMobile/Assets/Lang/Strings.uk.resx
+++ b/OpenUtauMobile/Assets/Lang/Strings.uk.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -1623,4 +1623,46 @@
   <data name="PerformanceMonitor.AppShort" xml:space="preserve"><value>Заст.</value></data>
   <data name="PerformanceMonitor.SystemShort" xml:space="preserve"><value>Система</value></data>
   <data name="PerformanceMonitor.Fps" xml:space="preserve"><value>FPS</value></data>
+  <data name="PhonemePanel.EditMode.Switch" xml:space="preserve">
+    <value>Switch phoneme &amp; parameter edit mode</value>
+  </data>
+  <data name="PhonemePanel.Mode.Simple" xml:space="preserve">
+    <value>Simple phoneme mode</value>
+  </data>
+  <data name="PhonemePanel.Mode.Advanced" xml:space="preserve">
+    <value>Advanced phoneme mode</value>
+  </data>
+  <data name="PhonemePanel.Mode.Draw" xml:space="preserve">
+    <value>Parameter draw mode</value>
+  </data>
+  <data name="PhonemePanel.Mode.Erase" xml:space="preserve">
+    <value>Parameter erase mode</value>
+  </data>
+  <data name="PhonemePanel.Toast.Simple" xml:space="preserve">
+    <value>Switched to simple phoneme mode</value>
+  </data>
+  <data name="PhonemePanel.Toast.Advanced" xml:space="preserve">
+    <value>Switched to advanced phoneme mode</value>
+  </data>
+  <data name="PhonemePanel.Toast.Draw" xml:space="preserve">
+    <value>Switched to parameter draw mode</value>
+  </data>
+  <data name="PhonemePanel.Toast.Erase" xml:space="preserve">
+    <value>Switched to parameter erase mode</value>
+  </data>
+  <data name="PhonemePanel.Param.Primary" xml:space="preserve">
+    <value>Primary parameter</value>
+  </data>
+  <data name="PhonemePanel.Param.Secondary" xml:space="preserve">
+    <value>Background parameter</value>
+  </data>
+  <data name="PhonemePanel.Param.Swap" xml:space="preserve">
+    <value>Swap primary &amp; background parameters</value>
+  </data>
+  <data name="PhonemePanel.Param.None" xml:space="preserve">
+    <value>None</value>
+  </data>
+  <data name="PhonemePanel.Split.Tooltip" xml:space="preserve">
+    <value>Drag to resize phoneme/parameter panel</value>
+  </data>
 </root>

--- a/OpenUtauMobile/Assets/Lang/Strings.zh-Hans.resx
+++ b/OpenUtauMobile/Assets/Lang/Strings.zh-Hans.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -1648,4 +1648,58 @@
   <data name="PerformanceMonitor.AppShort" xml:space="preserve"><value>应用</value></data>
   <data name="PerformanceMonitor.SystemShort" xml:space="preserve"><value>系统</value></data>
   <data name="PerformanceMonitor.Fps" xml:space="preserve"><value>帧率</value></data>
+  <data name="PhonemePanel.EditMode.Switch" xml:space="preserve">
+    <value>切换音素与参数编辑模式</value>
+  </data>
+  <data name="PhonemePanel.Mode.Simple" xml:space="preserve">
+    <value>简易音素模式</value>
+  </data>
+  <data name="PhonemePanel.Mode.Advanced" xml:space="preserve">
+    <value>高级音素模式</value>
+  </data>
+  <data name="PhonemePanel.Mode.Draw" xml:space="preserve">
+    <value>参数绘制模式</value>
+  </data>
+  <data name="PhonemePanel.Mode.Erase" xml:space="preserve">
+    <value>参数擦除模式</value>
+  </data>
+  <data name="PhonemePanel.Toast.Simple" xml:space="preserve">
+    <value>简易音素模式</value>
+  </data>
+  <data name="PhonemePanel.Toast.Advanced" xml:space="preserve">
+    <value>高级音素模式</value>
+  </data>
+  <data name="PhonemePanel.Toast.Draw" xml:space="preserve">
+    <value>参数绘制模式</value>
+  </data>
+  <data name="PhonemePanel.Toast.Erase" xml:space="preserve">
+    <value>参数擦除模式</value>
+  </data>
+  <data name="PhonemePanel.Param.Primary" xml:space="preserve">
+    <value>主编辑参数</value>
+  </data>
+  <data name="PhonemePanel.Param.Secondary" xml:space="preserve">
+    <value>背景参考参数</value>
+  </data>
+  <data name="PhonemePanel.Param.Swap" xml:space="preserve">
+    <value>交换主/次参数</value>
+  </data>
+  <data name="PhonemePanel.Param.None" xml:space="preserve">
+    <value>无</value>
+  </data>
+  <data name="PhonemePanel.Split.Tooltip" xml:space="preserve">
+    <value>拖动调节音素与参数面板高度</value>
+  </data>
+  <data name="PhonemeEdit.Title" xml:space="preserve">
+    <value>编辑音素别名</value>
+  </data>
+  <data name="PhonemeEdit.Watermark" xml:space="preserve">
+    <value>默认别名（留空以恢复默认）</value>
+  </data>
+  <data name="PhonemeEdit.Reset" xml:space="preserve">
+    <value>恢复默认</value>
+  </data>
+  <data name="PhonemeEdit.Info" xml:space="preserve">
+    <value>音符: {0} | 音素 #{1}</value>
+  </data>
 </root>

--- a/OpenUtauMobile/Controls/ParameterCanvas.cs
+++ b/OpenUtauMobile/Controls/ParameterCanvas.cs
@@ -8,6 +8,7 @@ using Avalonia.Media.TextFormatting;
 using OpenUtau.Core;
 using OpenUtau.Core.Ustx;
 using OpenUtauMobile.Themes.OpenUtauMobile.Runtime;
+using OpenUtauMobile.ViewModels;
 
 namespace OpenUtauMobile.Controls;
 
@@ -83,21 +84,54 @@ public class ParameterCanvas : Control, ICmdSubscriber
     private readonly Geometry _pointGeometry = new EllipseGeometry(new Rect(-3.0, -3.0, 6.0, 6.0));
     private readonly Geometry _circleGeometry = new EllipseGeometry(new Rect(-4.0, -4.0, 8.0, 8.0));
 
+    private PianoRollViewModel? _viewModel;
+    private PianoRollViewModel? ViewModel => _viewModel ?? (DataContext as PianoRollViewModel);
+
     public ParameterCanvas()
     {
         ClipToBounds = true;
+    }
+
+    protected override void OnDataContextChanged(EventArgs e)
+    {
+        base.OnDataContextChanged(e);
+        if (_viewModel != null)
+        {
+            _viewModel.RequestInvalidateVisual -= InvalidateVisual;
+        }
+
+        _viewModel = DataContext as PianoRollViewModel;
+
+        if (_viewModel != null)
+        {
+            _viewModel.RequestInvalidateVisual += InvalidateVisual;
+        }
     }
 
     protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
     {
         base.OnAttachedToVisualTree(e);
         DocManager.Inst.AddSubscriber(this);
+        if (DataContext is PianoRollViewModel vm)
+        {
+            if (_viewModel != null)
+            {
+                _viewModel.RequestInvalidateVisual -= InvalidateVisual;
+            }
+            _viewModel = vm;
+            _viewModel.RequestInvalidateVisual += InvalidateVisual;
+        }
     }
 
     protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
     {
         base.OnDetachedFromVisualTree(e);
         DocManager.Inst.RemoveSubscriber(this);
+        if (_viewModel != null)
+        {
+            _viewModel.RequestInvalidateVisual -= InvalidateVisual;
+            _viewModel = null;
+        }
     }
 
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)

--- a/OpenUtauMobile/Controls/ParameterCanvas.cs
+++ b/OpenUtauMobile/Controls/ParameterCanvas.cs
@@ -382,6 +382,7 @@ public class ParameterCanvas : Control, ICmdSubscriber
         _lastValue = value;
 
         ApplyEditAt(project, track, descriptor, tick, value, tick, value);
+        UpdateEditingTip(descriptor, tick, value);
         InvalidateVisual();
         e.Handled = true;
     }
@@ -413,6 +414,7 @@ public class ParameterCanvas : Control, ICmdSubscriber
         int value = CalculateValueFromY(pos.Y, descriptor);
 
         ApplyEditAt(project, track, descriptor, tick, value, _lastTick, _lastValue);
+        UpdateEditingTip(descriptor, tick, value);
 
         _lastTick = tick;
         _lastValue = value;
@@ -430,6 +432,10 @@ public class ParameterCanvas : Control, ICmdSubscriber
             _drawingPointer = null;
             DocManager.Inst.EndUndoGroup();
             e.Pointer.Capture(null);
+            if (ViewModel != null)
+            {
+                ViewModel.EditingTip = string.Empty;
+            }
             InvalidateVisual();
             e.Handled = true;
         }
@@ -443,8 +449,83 @@ public class ParameterCanvas : Control, ICmdSubscriber
             _isDrawing = false;
             _drawingPointer = null;
             DocManager.Inst.EndUndoGroup();
+            if (ViewModel != null)
+            {
+                ViewModel.EditingTip = string.Empty;
+            }
             InvalidateVisual();
         }
+    }
+
+    private void UpdateEditingTip(UExpressionDescriptor descriptor, int tick, int value)
+    {
+        if (ViewModel == null)
+        {
+            return;
+        }
+
+        if (descriptor.type == UExpressionType.Curve)
+        {
+            if (IsEraseMode)
+            {
+                ViewModel.EditingTip = $"{descriptor.name}: Erase (Default: {descriptor.defaultValue:F0})";
+            }
+            else
+            {
+                ViewModel.EditingTip = $"{descriptor.name}: {value:+0;-0;0}";
+            }
+            return;
+        }
+
+        UPhoneme? phoneme = FindPhonemeAtTick(tick);
+        string phonemePrefix = phoneme != null
+            ? $"[{(string.IsNullOrEmpty(phoneme.phonemeMapped) ? phoneme.phoneme : phoneme.phonemeMapped)}] "
+            : string.Empty;
+
+        if (descriptor.type == UExpressionType.Numerical)
+        {
+            if (IsEraseMode)
+            {
+                ViewModel.EditingTip = $"{phonemePrefix}{descriptor.name}: Reset (Default: {descriptor.defaultValue:F0})";
+            }
+            else
+            {
+                ViewModel.EditingTip = $"{phonemePrefix}{descriptor.name}: {value}";
+            }
+        }
+        else if (descriptor.type == UExpressionType.Options)
+        {
+            string optName = (descriptor.options != null && value >= 0 && value < descriptor.options.Length)
+                ? descriptor.options[value]
+                : value.ToString();
+            if (IsEraseMode)
+            {
+                ViewModel.EditingTip = $"{phonemePrefix}{descriptor.name}: Reset";
+            }
+            else
+            {
+                ViewModel.EditingTip = $"{phonemePrefix}{descriptor.name}: {optName}";
+            }
+        }
+    }
+
+    private UPhoneme? FindPhonemeAtTick(int tick)
+    {
+        if (Part == null)
+        {
+            return null;
+        }
+
+        double partRelativeTick = tick - Part.position;
+        foreach (UPhoneme phoneme in Part.phonemes)
+        {
+            if (partRelativeTick >= phoneme.position && partRelativeTick <= phoneme.End)
+            {
+                return phoneme;
+            }
+        }
+
+        return null;
     }
 
     private int CalculateValueFromY(double y, UExpressionDescriptor descriptor)

--- a/OpenUtauMobile/Controls/ParameterCanvas.cs
+++ b/OpenUtauMobile/Controls/ParameterCanvas.cs
@@ -1,0 +1,483 @@
+using System;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Media.TextFormatting;
+using OpenUtau.Core;
+using OpenUtau.Core.Ustx;
+using OpenUtauMobile.Themes.OpenUtauMobile.Runtime;
+
+namespace OpenUtauMobile.Controls;
+
+/// <summary>
+/// 参数曲线与表情画布：支持多音轨/声部的曲线绘制（Curve）以及逐音素表情参数（Numerical / Options）的绘制与擦除。
+/// 顶部留有安全边距避开上方分割手柄。
+/// </summary>
+public class ParameterCanvas : Control, ICmdSubscriber
+{
+    public static readonly StyledProperty<UVoicePart?> PartProperty =
+        AvaloniaProperty.Register<ParameterCanvas, UVoicePart?>(nameof(Part));
+
+    public static readonly StyledProperty<double> TickWidthProperty =
+        AvaloniaProperty.Register<ParameterCanvas, double>(nameof(TickWidth), 0.1);
+
+    public static readonly StyledProperty<double> TickOffsetProperty =
+        AvaloniaProperty.Register<ParameterCanvas, double>(nameof(TickOffset));
+
+    public static readonly StyledProperty<string> PrimaryKeyProperty =
+        AvaloniaProperty.Register<ParameterCanvas, string>(nameof(PrimaryKey), "vel");
+
+    public static readonly StyledProperty<string> SecondaryKeyProperty =
+        AvaloniaProperty.Register<ParameterCanvas, string>(nameof(SecondaryKey), string.Empty);
+
+    public static readonly StyledProperty<bool> IsEraseModeProperty =
+        AvaloniaProperty.Register<ParameterCanvas, bool>(nameof(IsEraseMode));
+
+    public UVoicePart? Part
+    {
+        get => GetValue(PartProperty);
+        set => SetValue(PartProperty, value);
+    }
+
+    public double TickWidth
+    {
+        get => GetValue(TickWidthProperty);
+        set => SetValue(TickWidthProperty, value);
+    }
+
+    public double TickOffset
+    {
+        get => GetValue(TickOffsetProperty);
+        set => SetValue(TickOffsetProperty, value);
+    }
+
+    public string PrimaryKey
+    {
+        get => GetValue(PrimaryKeyProperty);
+        set => SetValue(PrimaryKeyProperty, value);
+    }
+
+    public string SecondaryKey
+    {
+        get => GetValue(SecondaryKeyProperty);
+        set => SetValue(SecondaryKeyProperty, value);
+    }
+
+    public bool IsEraseMode
+    {
+        get => GetValue(IsEraseModeProperty);
+        set => SetValue(IsEraseModeProperty, value);
+    }
+
+    private const double TopMargin = 14.0;
+    private const double BottomMargin = 6.0;
+
+    // 绘制与触摸交互状态
+    private bool _isDrawing;
+    private int _lastTick;
+    private int _lastValue;
+    private Point? _drawingPointer;
+
+    private readonly Geometry _pointGeometry = new EllipseGeometry(new Rect(-3.0, -3.0, 6.0, 6.0));
+    private readonly Geometry _circleGeometry = new EllipseGeometry(new Rect(-4.0, -4.0, 8.0, 8.0));
+
+    public ParameterCanvas()
+    {
+        ClipToBounds = true;
+    }
+
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+        DocManager.Inst.AddSubscriber(this);
+    }
+
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnDetachedFromVisualTree(e);
+        DocManager.Inst.RemoveSubscriber(this);
+    }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+        if (change.Property == PartProperty ||
+            change.Property == TickWidthProperty ||
+            change.Property == TickOffsetProperty ||
+            change.Property == PrimaryKeyProperty ||
+            change.Property == SecondaryKeyProperty ||
+            change.Property == IsEraseModeProperty)
+        {
+            InvalidateVisual();
+        }
+    }
+
+    public override void Render(DrawingContext context)
+    {
+        base.Render(context);
+        if (Part == null || Bounds.Width <= 0 || Bounds.Height <= 0 || DocManager.Inst.Project == null)
+        {
+            return;
+        }
+
+        IBrush bgBrush = ThemeResources.GetBrush("Sem.Color.SurfaceContainerLow");
+        context.DrawRectangle(bgBrush, null, new Rect(0, 0, Bounds.Width, Bounds.Height));
+
+        UProject project = DocManager.Inst.Project;
+        if (Part.trackNo < 0 || Part.trackNo >= project.tracks.Count)
+        {
+            return;
+        }
+
+        UTrack track = project.tracks[Part.trackNo];
+
+        // 1. 绘制背景次要参数（低不透明度）
+        if (!string.IsNullOrEmpty(SecondaryKey) && SecondaryKey != PrimaryKey)
+        {
+            if (track.TryGetExpDescriptor(project, SecondaryKey, out UExpressionDescriptor? secDesc))
+            {
+                using (context.PushOpacity(0.28))
+                {
+                    RenderExpression(context, project, track, secDesc, false);
+                }
+            }
+        }
+
+        // 2. 绘制主参数
+        if (!string.IsNullOrEmpty(PrimaryKey))
+        {
+            if (track.TryGetExpDescriptor(project, PrimaryKey, out UExpressionDescriptor? priDesc))
+            {
+                RenderExpression(context, project, track, priDesc, true);
+            }
+        }
+
+        // 3. 绘制触点光标
+        if (_isDrawing && _drawingPointer.HasValue)
+        {
+            Point center = _drawingPointer.Value;
+            IBrush haloBrush = ThemeResources.GetBrush(IsEraseMode ? "Sem.Color.Error" : "Sem.Color.Primary");
+            using (context.PushOpacity(0.25))
+            {
+                context.DrawEllipse(haloBrush, null, center, 10.0, 10.0);
+            }
+            context.DrawEllipse(haloBrush, null, center, 3.5, 3.5);
+        }
+    }
+
+    private void RenderExpression(
+        DrawingContext context,
+        UProject project,
+        UTrack track,
+        UExpressionDescriptor descriptor,
+        bool isPrimary)
+    {
+        if (descriptor.max <= descriptor.min || Part == null)
+        {
+            return;
+        }
+
+        double leftTick = TickOffset - 480;
+        double rightTick = TickOffset + Bounds.Width / TickWidth + 480;
+        double canvasHeight = Bounds.Height;
+        double usableHeight = Math.Max(16.0, canvasHeight - TopMargin - BottomMargin);
+        double valueRange = descriptor.max - descriptor.min;
+
+        IPen linePen = isPrimary ? ThemeResources.GetPen("Sem.Color.Primary", 2.0) : ThemeResources.GetPen("Sem.Color.Secondary", 1.5);
+        IPen faintPen = ThemeResources.GetPen("Sem.Color.OutlineVariant", 1.0);
+        IBrush fillBrush = isPrimary ? ThemeResources.GetBrush("Sem.Color.Primary") : ThemeResources.GetBrush("Sem.Color.Secondary");
+
+        // ── 曲线类型 ─────────────────────────────────────────────────────────
+        if (descriptor.type == UExpressionType.Curve)
+        {
+            UCurve? curve = Part.curves.FirstOrDefault(c => c.descriptor == descriptor || c.abbr == descriptor.abbr);
+            double defaultHeight = Math.Round(TopMargin + usableHeight * (1.0 - (descriptor.defaultValue - descriptor.min) / valueRange));
+
+            // 绘制默认值参考基线
+            context.DrawLine(faintPen, new Point(0, defaultHeight), new Point(Bounds.Width, defaultHeight));
+
+            if (curve == null || curve.xs.Count == 0)
+            {
+                context.DrawLine(linePen, new Point(0, defaultHeight), new Point(Bounds.Width, defaultHeight));
+                return;
+            }
+
+            int lTick = (int)Math.Floor(leftTick / 5) * 5;
+            int rTick = (int)Math.Ceiling(rightTick / 5) * 5;
+
+            int index = curve.xs.BinarySearch(lTick);
+            if (index < 0)
+            {
+                index = ~index;
+            }
+            index = Math.Max(0, index - 1);
+
+            while (index < curve.xs.Count)
+            {
+                float tick1 = index < 0 ? lTick : curve.xs[index];
+                float val1 = index < 0 ? descriptor.defaultValue : curve.ys[index];
+                double x1 = (tick1 - TickOffset) * TickWidth;
+                double y1 = TopMargin + usableHeight * (1.0 - (val1 - descriptor.min) / valueRange);
+
+                float tick2 = index == curve.xs.Count - 1 ? rTick : curve.xs[index + 1];
+                float val2 = index == curve.xs.Count - 1 ? descriptor.defaultValue : curve.ys[index + 1];
+                double x2 = (tick2 - TickOffset) * TickWidth;
+                double y2 = TopMargin + usableHeight * (1.0 - (val2 - descriptor.min) / valueRange);
+
+                context.DrawLine(linePen, new Point(x1, y1), new Point(x2, y2));
+
+                index++;
+                if (tick2 >= rTick)
+                {
+                    break;
+                }
+            }
+            return;
+        }
+
+        // ── 数值与选项类型（逐音素显示） ──────────────────────────────────────────
+        double optionHeight = descriptor.type == UExpressionType.Options && descriptor.options != null && descriptor.options.Length > 0
+            ? usableHeight / descriptor.options.Length
+            : 0;
+
+        foreach (UPhoneme phoneme in Part.phonemes)
+        {
+            if (phoneme.Parent == null || phoneme.Error)
+            {
+                continue;
+            }
+
+            double phonemeAbsStart = Part.position + phoneme.position;
+            double phonemeAbsEnd = Part.position + phoneme.End;
+
+            if (phonemeAbsEnd < leftTick || phonemeAbsStart > rightTick)
+            {
+                continue;
+            }
+
+            double x1 = (phonemeAbsStart - TickOffset) * TickWidth;
+            double x2 = (phonemeAbsEnd - TickOffset) * TickWidth;
+            (float value, bool overridden) = phoneme.GetExpression(project, track, descriptor.abbr);
+
+            if (descriptor.type == UExpressionType.Numerical)
+            {
+                double valY = Math.Round(TopMargin + usableHeight * (1.0 - (value - descriptor.min) / valueRange));
+                double zeroY = Math.Round(TopMargin + usableHeight * (1.0 - (0f - descriptor.min) / valueRange));
+
+                context.DrawLine(linePen, new Point(x1 + 0.5, zeroY), new Point(x1 + 0.5, valY));
+                context.DrawLine(linePen, new Point(x1, valY), new Point(Math.Max(x1 + 4.0, x2 - 2.0), valY));
+
+                using (context.PushTransform(Matrix.CreateTranslation(x1 + 0.5, valY)))
+                {
+                    context.DrawGeometry(overridden ? fillBrush : Brushes.Transparent, linePen, _pointGeometry);
+                }
+            }
+            else if (descriptor.type == UExpressionType.Options && descriptor.options != null)
+            {
+                for (int i = 0; i < descriptor.options.Length; i++)
+                {
+                    double y = TopMargin + optionHeight * (descriptor.options.Length - 1 - i + 0.5);
+                    using (context.PushTransform(Matrix.CreateTranslation(x1 + 6.0, y)))
+                    {
+                        if ((int)value == i)
+                        {
+                            context.DrawGeometry(overridden ? fillBrush : Brushes.Transparent, linePen, _circleGeometry);
+                        }
+                        else
+                        {
+                            context.DrawGeometry(null, faintPen, _circleGeometry);
+                        }
+                    }
+                }
+            }
+        }
+
+        // 绘制选项文字标签
+        if (descriptor.type == UExpressionType.Options && descriptor.options != null && isPrimary)
+        {
+            IBrush labelBrush = ThemeResources.GetBrush("Sem.Color.OnSurfaceVariant");
+            for (int i = 0; i < descriptor.options.Length; i++)
+            {
+                string optionName = descriptor.options[i];
+                if (string.IsNullOrEmpty(optionName))
+                {
+                    optionName = $"[{i}]";
+                }
+                TextLayout textLayout = TextLayoutCache.Get(optionName, labelBrush, 10, false);
+                double y = TopMargin + optionHeight * (descriptor.options.Length - 1 - i + 0.5) - textLayout.Height * 0.5;
+                using (context.PushTransform(Matrix.CreateTranslation(6.0, y)))
+                {
+                    textLayout.Draw(context, new Point(0, 0));
+                }
+            }
+        }
+    }
+
+    protected override void OnPointerPressed(PointerPressedEventArgs e)
+    {
+        base.OnPointerPressed(e);
+        if (Part == null || DocManager.Inst.Project == null || string.IsNullOrEmpty(PrimaryKey))
+        {
+            return;
+        }
+
+        UProject project = DocManager.Inst.Project;
+        if (Part.trackNo < 0 || Part.trackNo >= project.tracks.Count)
+        {
+            return;
+        }
+
+        UTrack track = project.tracks[Part.trackNo];
+        if (!track.TryGetExpDescriptor(project, PrimaryKey, out UExpressionDescriptor? descriptor) || descriptor == null)
+        {
+            return;
+        }
+
+        Point pos = e.GetPosition(this);
+        _isDrawing = true;
+        _drawingPointer = pos;
+        e.Pointer.Capture(this);
+        DocManager.Inst.StartUndoGroup();
+
+        int tick = (int)(pos.X / TickWidth + TickOffset);
+        int value = CalculateValueFromY(pos.Y, descriptor);
+
+        _lastTick = tick;
+        _lastValue = value;
+
+        ApplyEditAt(project, track, descriptor, tick, value, tick, value);
+        InvalidateVisual();
+        e.Handled = true;
+    }
+
+    protected override void OnPointerMoved(PointerEventArgs e)
+    {
+        base.OnPointerMoved(e);
+        if (!_isDrawing || Part == null || DocManager.Inst.Project == null || string.IsNullOrEmpty(PrimaryKey))
+        {
+            return;
+        }
+
+        UProject project = DocManager.Inst.Project;
+        if (Part.trackNo < 0 || Part.trackNo >= project.tracks.Count)
+        {
+            return;
+        }
+
+        UTrack track = project.tracks[Part.trackNo];
+        if (!track.TryGetExpDescriptor(project, PrimaryKey, out UExpressionDescriptor? descriptor) || descriptor == null)
+        {
+            return;
+        }
+
+        Point pos = e.GetPosition(this);
+        _drawingPointer = pos;
+
+        int tick = (int)(pos.X / TickWidth + TickOffset);
+        int value = CalculateValueFromY(pos.Y, descriptor);
+
+        ApplyEditAt(project, track, descriptor, tick, value, _lastTick, _lastValue);
+
+        _lastTick = tick;
+        _lastValue = value;
+
+        InvalidateVisual();
+        e.Handled = true;
+    }
+
+    protected override void OnPointerReleased(PointerReleasedEventArgs e)
+    {
+        base.OnPointerReleased(e);
+        if (_isDrawing)
+        {
+            _isDrawing = false;
+            _drawingPointer = null;
+            DocManager.Inst.EndUndoGroup();
+            e.Pointer.Capture(null);
+            InvalidateVisual();
+            e.Handled = true;
+        }
+    }
+
+    protected override void OnPointerCaptureLost(PointerCaptureLostEventArgs e)
+    {
+        base.OnPointerCaptureLost(e);
+        if (_isDrawing)
+        {
+            _isDrawing = false;
+            _drawingPointer = null;
+            DocManager.Inst.EndUndoGroup();
+            InvalidateVisual();
+        }
+    }
+
+    private int CalculateValueFromY(double y, UExpressionDescriptor descriptor)
+    {
+        double usableHeight = Math.Max(16.0, Bounds.Height - TopMargin - BottomMargin);
+        if (descriptor.type == UExpressionType.Options && descriptor.options != null && descriptor.options.Length > 0)
+        {
+            double optionHeight = usableHeight / descriptor.options.Length;
+            int optionIndex = descriptor.options.Length - 1 - (int)Math.Clamp(Math.Floor((y - TopMargin) / optionHeight), 0, descriptor.options.Length - 1);
+            return optionIndex;
+        }
+
+        double ratio = Math.Clamp(1.0 - (y - TopMargin) / usableHeight, 0.0, 1.0);
+        float val = descriptor.min + (float)(ratio * (descriptor.max - descriptor.min));
+        if (IsEraseMode)
+        {
+            return (int)descriptor.defaultValue;
+        }
+        return (int)Math.Round(val);
+    }
+
+    private void ApplyEditAt(
+        UProject project,
+        UTrack track,
+        UExpressionDescriptor descriptor,
+        int tick,
+        int value,
+        int lastTick,
+        int lastValue)
+    {
+        if (Part == null)
+        {
+            return;
+        }
+
+        if (descriptor.type == UExpressionType.Curve)
+        {
+            int targetVal = IsEraseMode ? (int)descriptor.defaultValue : value;
+            int targetLastVal = IsEraseMode ? (int)descriptor.defaultValue : lastValue;
+            DocManager.Inst.ExecuteCmd(new SetCurveCommand(project, Part, descriptor.abbr, tick, targetVal, lastTick, targetLastVal));
+            return;
+        }
+
+        // 数值或选项：找到触摸点对应的音素
+        double partRelativeTick = tick - Part.position;
+        foreach (UPhoneme phoneme in Part.phonemes)
+        {
+            if (partRelativeTick >= phoneme.position && partRelativeTick <= phoneme.End)
+            {
+                float? newVal = IsEraseMode ? null : (float?)value;
+                DocManager.Inst.ExecuteCmd(new SetPhonemeExpressionCommand(project, track, Part, phoneme, descriptor.abbr, newVal));
+                break;
+            }
+        }
+    }
+
+    public void OnNext(UCommand cmd, bool isUndo)
+    {
+        switch (cmd)
+        {
+            case NoteCommand:
+            case PartCommand:
+            case SetCurveCommand:
+            case ExpCommand:
+            case PhonemizedNotification:
+                InvalidateVisual();
+                break;
+        }
+    }
+}

--- a/OpenUtauMobile/Controls/ParameterPanelToolbar.axaml
+++ b/OpenUtauMobile/Controls/ParameterPanelToolbar.axaml
@@ -27,7 +27,7 @@
                 <Button.Flyout>
                     <MenuFlyout ItemsSource="{Binding AvailableExpressions}">
                         <MenuFlyout.ItemContainerTheme>
-                            <ControlTheme TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}" x:DataType="ustx:UExpressionDescriptor">
+                            <ControlTheme TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}" x:DataType="vm:ExpressionOption">
                                 <Setter Property="Header" Value="{Binding DisplayName}" />
                                 <Setter Property="Command" Value="{Binding $parent[UserControl].((vm:PianoRollViewModel)DataContext).SelectPrimaryExpressionCommand}" />
                                 <Setter Property="CommandParameter" Value="{Binding}" />
@@ -37,7 +37,7 @@
                 </Button.Flyout>
                 <Grid ColumnDefinitions="*,Auto" Margin="2,0">
                     <TextBlock Grid.Column="0"
-                               Text="{Binding PrimaryExpressionDescriptor.DisplayName}"
+                               Text="{Binding PrimaryExpressionDisplayName}"
                                FontWeight="Bold"
                                FontSize="11"
                                Foreground="{DynamicResource Sem.Color.Primary}"
@@ -78,7 +78,7 @@
                 <Button.Flyout>
                     <MenuFlyout ItemsSource="{Binding AvailableSecondaryExpressions}">
                         <MenuFlyout.ItemContainerTheme>
-                            <ControlTheme TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}" x:DataType="ustx:UExpressionDescriptor">
+                            <ControlTheme TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}" x:DataType="vm:ExpressionOption">
                                 <Setter Property="Header" Value="{Binding DisplayName}" />
                                 <Setter Property="Command" Value="{Binding $parent[UserControl].((vm:PianoRollViewModel)DataContext).SelectSecondaryExpressionCommand}" />
                                 <Setter Property="CommandParameter" Value="{Binding}" />
@@ -88,7 +88,7 @@
                 </Button.Flyout>
                 <Grid ColumnDefinitions="*,Auto" Margin="2,0">
                     <TextBlock Grid.Column="0"
-                               Text="{Binding SecondaryExpressionDescriptor.DisplayName}"
+                               Text="{Binding SecondaryExpressionDisplayName}"
                                FontSize="11"
                                Opacity="0.8"
                                TextTrimming="CharacterEllipsis"

--- a/OpenUtauMobile/Controls/ParameterPanelToolbar.axaml
+++ b/OpenUtauMobile/Controls/ParameterPanelToolbar.axaml
@@ -1,0 +1,108 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:iconPacks="https://github.com/MahApps/IconPacks.Avalonia"
+             xmlns:ustx="clr-namespace:OpenUtau.Core.Ustx;assembly=OpenUtau.Core"
+             xmlns:vm="clr-namespace:OpenUtauMobile.ViewModels"
+             xmlns:theme="clr-namespace:OpenUtauMobile.Themes.OpenUtauMobile.Runtime"
+             x:Class="OpenUtauMobile.Controls.ParameterPanelToolbar"
+             x:DataType="vm:PianoRollViewModel">
+
+    <Border Background="{DynamicResource Sem.Color.SurfaceContainer}"
+            BorderBrush="{DynamicResource Sem.Color.OutlineVariant}"
+            BorderThickness="0,0,1,0"
+            Padding="3,4">
+        <StackPanel Orientation="Vertical"
+                    VerticalAlignment="Center"
+                    HorizontalAlignment="Stretch"
+                    Spacing="4">
+            <!-- 主参数选择按钮 -->
+            <Button HorizontalAlignment="Stretch"
+                    Height="28"
+                    Padding="2,0"
+                    CornerRadius="{x:Static theme:ThemeBaseShapeTokens.CornerS}"
+                    Background="{DynamicResource Sem.Color.SurfaceContainerHigh}"
+                    BorderBrush="{DynamicResource Sem.Color.OutlineVariant}"
+                    BorderThickness="1"
+                    ToolTip.Tip="{DynamicResource PhonemePanel.Param.Primary}">
+                <Button.Flyout>
+                    <MenuFlyout ItemsSource="{Binding AvailableExpressions}">
+                        <MenuFlyout.ItemContainerTheme>
+                            <ControlTheme TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}" x:DataType="ustx:UExpressionDescriptor">
+                                <Setter Property="Header" Value="{Binding DisplayName}" />
+                                <Setter Property="Command" Value="{Binding $parent[UserControl].((vm:PianoRollViewModel)DataContext).SelectPrimaryExpressionCommand}" />
+                                <Setter Property="CommandParameter" Value="{Binding}" />
+                            </ControlTheme>
+                        </MenuFlyout.ItemContainerTheme>
+                    </MenuFlyout>
+                </Button.Flyout>
+                <Grid ColumnDefinitions="*,Auto" Margin="2,0">
+                    <TextBlock Grid.Column="0"
+                               Text="{Binding PrimaryExpressionDescriptor.DisplayName}"
+                               FontWeight="Bold"
+                               FontSize="11"
+                               Foreground="{DynamicResource Sem.Color.Primary}"
+                               TextTrimming="CharacterEllipsis"
+                               HorizontalAlignment="Center"
+                               VerticalAlignment="Center" />
+                    <iconPacks:PackIconPhosphorIcons Grid.Column="1"
+                                                    Kind="CaretDown"
+                                                    Width="8"
+                                                    Height="8"
+                                                    Foreground="{DynamicResource Sem.Color.Primary}"
+                                                    VerticalAlignment="Center"
+                                                    Margin="2,0,0,0" />
+                </Grid>
+            </Button>
+
+            <!-- 交换按钮 -->
+            <Button Command="{Binding SwapExpressionsCommand}"
+                    HorizontalAlignment="Center"
+                    Width="32"
+                    Height="24"
+                    Padding="0"
+                    CornerRadius="{x:Static theme:ThemeBaseShapeTokens.CornerS}"
+                    Background="Transparent"
+                    ToolTip.Tip="{DynamicResource PhonemePanel.Param.Swap}">
+                <iconPacks:PackIconPhosphorIcons Kind="ArrowsDownUp" Width="14" Height="14" />
+            </Button>
+
+            <!-- 背景参数选择按钮 -->
+            <Button HorizontalAlignment="Stretch"
+                    Height="28"
+                    Padding="2,0"
+                    CornerRadius="{x:Static theme:ThemeBaseShapeTokens.CornerS}"
+                    Background="{DynamicResource Sem.Color.SurfaceContainerHigh}"
+                    BorderBrush="{DynamicResource Sem.Color.OutlineVariant}"
+                    BorderThickness="1"
+                    ToolTip.Tip="{DynamicResource PhonemePanel.Param.Secondary}">
+                <Button.Flyout>
+                    <MenuFlyout ItemsSource="{Binding AvailableSecondaryExpressions}">
+                        <MenuFlyout.ItemContainerTheme>
+                            <ControlTheme TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}" x:DataType="ustx:UExpressionDescriptor">
+                                <Setter Property="Header" Value="{Binding DisplayName}" />
+                                <Setter Property="Command" Value="{Binding $parent[UserControl].((vm:PianoRollViewModel)DataContext).SelectSecondaryExpressionCommand}" />
+                                <Setter Property="CommandParameter" Value="{Binding}" />
+                            </ControlTheme>
+                        </MenuFlyout.ItemContainerTheme>
+                    </MenuFlyout>
+                </Button.Flyout>
+                <Grid ColumnDefinitions="*,Auto" Margin="2,0">
+                    <TextBlock Grid.Column="0"
+                               Text="{Binding SecondaryExpressionDescriptor.DisplayName}"
+                               FontSize="11"
+                               Opacity="0.8"
+                               TextTrimming="CharacterEllipsis"
+                               HorizontalAlignment="Center"
+                               VerticalAlignment="Center" />
+                    <iconPacks:PackIconPhosphorIcons Grid.Column="1"
+                                                    Kind="CaretDown"
+                                                    Width="8"
+                                                    Height="8"
+                                                    Opacity="0.8"
+                                                    VerticalAlignment="Center"
+                                                    Margin="2,0,0,0" />
+                </Grid>
+            </Button>
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/OpenUtauMobile/Controls/ParameterPanelToolbar.axaml.cs
+++ b/OpenUtauMobile/Controls/ParameterPanelToolbar.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace OpenUtauMobile.Controls;
+
+public partial class ParameterPanelToolbar : UserControl
+{
+    public ParameterPanelToolbar()
+    {
+        InitializeComponent();
+    }
+}

--- a/OpenUtauMobile/Controls/PhonemeAdvancedCanvas.cs
+++ b/OpenUtauMobile/Controls/PhonemeAdvancedCanvas.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media;
 using Avalonia.Media.TextFormatting;
+using Avalonia.Threading;
 using OpenUtau.Core;
 using OpenUtau.Core.Ustx;
 using OpenUtauMobile.Themes.OpenUtauMobile.Runtime;
@@ -44,7 +45,8 @@ public class PhonemeAdvancedCanvas : Control, ICmdSubscriber
         set => SetValue(TickOffsetProperty, value);
     }
 
-    private PianoRollViewModel? ViewModel => DataContext as PianoRollViewModel;
+    private PianoRollViewModel? _viewModel;
+    private PianoRollViewModel? ViewModel => _viewModel ?? (DataContext as PianoRollViewModel);
 
     private enum AdvancedHandleType
     {
@@ -56,8 +58,17 @@ public class PhonemeAdvancedCanvas : Control, ICmdSubscriber
 
     private AdvancedHandleType _activeHandleType = AdvancedHandleType.None;
     private UPhoneme? _activePhoneme;
+    private UPhoneme? _animatingTimingPhoneme;
     private double _dragStartPointerX;
     private float _initialDelta;
+
+    // 手柄展开动效状态
+    private DispatcherTimer? _animTimer;
+    private double _animProgress;
+    private double _animStartProgress;
+    private double _animTargetProgress;
+    private DateTime _animStartTime;
+    private const double AnimDurationMs = 130.0;
 
     // 双击检测
     private DateTime _lastClickTime = DateTime.MinValue;
@@ -77,16 +88,82 @@ public class PhonemeAdvancedCanvas : Control, ICmdSubscriber
         ClipToBounds = true;
     }
 
+    private void StartDragAnimation(double target)
+    {
+        _animStartProgress = _animProgress;
+        _animTargetProgress = target;
+        _animStartTime = DateTime.UtcNow;
+
+        if (_animTimer == null)
+        {
+            _animTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(16) };
+            _animTimer.Tick += OnAnimTimerTick;
+        }
+        _animTimer.Start();
+    }
+
+    private void OnAnimTimerTick(object? sender, EventArgs e)
+    {
+        double elapsed = (DateTime.UtcNow - _animStartTime).TotalMilliseconds;
+        double t = Math.Clamp(elapsed / AnimDurationMs, 0.0, 1.0);
+        // CubicEaseOut
+        double eased = 1.0 - Math.Pow(1.0 - t, 3);
+        _animProgress = _animStartProgress + (_animTargetProgress - _animStartProgress) * eased;
+
+        InvalidateVisual();
+
+        if (t >= 1.0)
+        {
+            _animProgress = _animTargetProgress;
+            _animTimer?.Stop();
+            if (_animProgress <= 0.0 && _activeHandleType != AdvancedHandleType.TimingLine)
+            {
+                _animatingTimingPhoneme = null;
+            }
+        }
+    }
+
+    protected override void OnDataContextChanged(EventArgs e)
+    {
+        base.OnDataContextChanged(e);
+        if (_viewModel != null)
+        {
+            _viewModel.RequestInvalidateVisual -= InvalidateVisual;
+        }
+
+        _viewModel = DataContext as PianoRollViewModel;
+
+        if (_viewModel != null)
+        {
+            _viewModel.RequestInvalidateVisual += InvalidateVisual;
+        }
+    }
+
     protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
     {
         base.OnAttachedToVisualTree(e);
         DocManager.Inst.AddSubscriber(this);
+        if (DataContext is PianoRollViewModel vm)
+        {
+            if (_viewModel != null)
+            {
+                _viewModel.RequestInvalidateVisual -= InvalidateVisual;
+            }
+            _viewModel = vm;
+            _viewModel.RequestInvalidateVisual += InvalidateVisual;
+        }
     }
 
     protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
     {
         base.OnDetachedFromVisualTree(e);
         DocManager.Inst.RemoveSubscriber(this);
+        _animTimer?.Stop();
+        if (_viewModel != null)
+        {
+            _viewModel.RequestInvalidateVisual -= InvalidateVisual;
+            _viewModel = null;
+        }
     }
 
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
@@ -155,7 +232,7 @@ public class PhonemeAdvancedCanvas : Control, ICmdSubscriber
             if (!phoneme.Error && phoneme.envelope.data.Count >= 5)
             {
                 double posMs = phoneme.PositionMs;
-                var timeAxis = DocManager.Inst.Project.timeAxis;
+                TimeAxis timeAxis = DocManager.Inst.Project.timeAxis;
 
                 double x0 = (timeAxis.MsPosToTickPos(posMs + phoneme.envelope.data[0].X) - TickOffset) * TickWidth;
                 double y0 = envelopeTopY + (1.0 - phoneme.envelope.data[0].Y / 100.0) * envelopeHeight;
@@ -204,8 +281,20 @@ public class PhonemeAdvancedCanvas : Control, ICmdSubscriber
             }
 
             // 3. 绘制垂直位置基准线
-            IPen linePen = phoneme.rawPosition != phoneme.position ? timingThickPen : timingPen;
-            context.DrawLine(linePen, new Point(posX, TopMargin + 2), new Point(posX, envelopeTopY + envelopeHeight + 2));
+            bool isModifiedTiming = phoneme.rawPosition != phoneme.position;
+            bool isAnimTarget = _animatingTimingPhoneme == phoneme && _animProgress > 0.001;
+            double progress = isAnimTarget ? _animProgress : 0.0;
+
+            double expansion = 6.0 * progress; // 拖拽时平滑上下延伸 6dp
+            double thicknessBonus = 1.2 * progress;
+            double lineThickness = (isModifiedTiming ? 3.0 : 1.5) + thicknessBonus;
+            IPen linePen = (isModifiedTiming || progress > 0.001)
+                ? ThemeResources.GetPen("Sem.Color.Primary", lineThickness)
+                : (isModifiedTiming ? timingThickPen : timingPen);
+
+            double lineTop = TopMargin + 2.0 - expansion;
+            double lineBottom = envelopeTopY + envelopeHeight + 2.0 + expansion;
+            context.DrawLine(linePen, new Point(posX, lineTop), new Point(posX, lineBottom));
 
             // 4. 绘制音素标签药丸框（置于顶部留白下方）
             string labelText = !string.IsNullOrEmpty(phoneme.phonemeMapped) ? phoneme.phonemeMapped : phoneme.phoneme;
@@ -245,6 +334,11 @@ public class PhonemeAdvancedCanvas : Control, ICmdSubscriber
         {
             _activeHandleType = hitType;
             _activePhoneme = hitPhoneme;
+            if (hitType == AdvancedHandleType.TimingLine)
+            {
+                _animatingTimingPhoneme = hitPhoneme;
+                StartDragAnimation(1.0);
+            }
             _dragStartPointerX = pos.X;
             UPhonemeOverride overrideData = hitPhoneme.Parent.GetPhonemeOverride(hitPhoneme.index);
 
@@ -322,6 +416,10 @@ public class PhonemeAdvancedCanvas : Control, ICmdSubscriber
         base.OnPointerReleased(e);
         if (_activeHandleType != AdvancedHandleType.None)
         {
+            if (_activeHandleType == AdvancedHandleType.TimingLine)
+            {
+                StartDragAnimation(0.0);
+            }
             _activeHandleType = AdvancedHandleType.None;
             _activePhoneme = null;
             DocManager.Inst.EndUndoGroup();
@@ -336,6 +434,10 @@ public class PhonemeAdvancedCanvas : Control, ICmdSubscriber
         base.OnPointerCaptureLost(e);
         if (_activeHandleType != AdvancedHandleType.None)
         {
+            if (_activeHandleType == AdvancedHandleType.TimingLine)
+            {
+                StartDragAnimation(0.0);
+            }
             _activeHandleType = AdvancedHandleType.None;
             _activePhoneme = null;
             DocManager.Inst.EndUndoGroup();
@@ -353,7 +455,7 @@ public class PhonemeAdvancedCanvas : Control, ICmdSubscriber
         double totalHeight = Bounds.Height;
         double envelopeTopY = TopMargin + LabelHeight + 4.0;
         double envelopeHeight = Math.Max(20.0, totalHeight - envelopeTopY - BottomMargin);
-        var timeAxis = DocManager.Inst.Project.timeAxis;
+        TimeAxis timeAxis = DocManager.Inst.Project.timeAxis;
 
         foreach (UPhoneme phoneme in Part.phonemes)
         {

--- a/OpenUtauMobile/Controls/PhonemeAdvancedCanvas.cs
+++ b/OpenUtauMobile/Controls/PhonemeAdvancedCanvas.cs
@@ -353,6 +353,18 @@ public class PhonemeAdvancedCanvas : Control, ICmdSubscriber
             e.Pointer.Capture(this);
             e.Handled = true;
             DocManager.Inst.StartUndoGroup();
+
+            string phonemeName = !string.IsNullOrEmpty(hitPhoneme.phonemeMapped) ? hitPhoneme.phonemeMapped : hitPhoneme.phoneme;
+            if (ViewModel != null)
+            {
+                ViewModel.EditingTip = hitType switch
+                {
+                    AdvancedHandleType.TimingLine => $"[{phonemeName}] Offset: {(int)_initialDelta:+0;-0;0} tick",
+                    AdvancedHandleType.Preutter => $"[{phonemeName}] Preutter: {_initialDelta:+0.0;-0.0;0.0} ms",
+                    AdvancedHandleType.Overlap => $"[{phonemeName}] Overlap: {_initialDelta:+0.0;-0.0;0.0} ms",
+                    _ => string.Empty
+                };
+            }
             return;
         }
 
@@ -391,19 +403,34 @@ public class PhonemeAdvancedCanvas : Control, ICmdSubscriber
         double deltaMs = DocManager.Inst.Project.timeAxis.TickPosToMsPos(Part.position + _activePhoneme.position + (int)deltaTicks)
                        - DocManager.Inst.Project.timeAxis.TickPosToMsPos(Part.position + _activePhoneme.position);
 
+        string phonemeName = !string.IsNullOrEmpty(_activePhoneme.phonemeMapped) ? _activePhoneme.phonemeMapped : _activePhoneme.phoneme;
         switch (_activeHandleType)
         {
             case AdvancedHandleType.TimingLine:
                 int newOffset = (int)(_initialDelta + deltaTicks);
                 DocManager.Inst.ExecuteCmd(new PhonemeOffsetCommand(Part, _activePhoneme.Parent, _activePhoneme.index, newOffset));
+                double offsetMs = DocManager.Inst.Project.timeAxis.TickPosToMsPos(Part.position + _activePhoneme.rawPosition + newOffset)
+                                - DocManager.Inst.Project.timeAxis.TickPosToMsPos(Part.position + _activePhoneme.rawPosition);
+                if (ViewModel != null)
+                {
+                    ViewModel.EditingTip = $"[{phonemeName}] Offset: {newOffset:+0;-0;0} tick ({offsetMs:+0.0;-0.0;0.0} ms)";
+                }
                 break;
             case AdvancedHandleType.Preutter:
                 float newPreutter = (float)(_initialDelta - deltaMs);
                 DocManager.Inst.ExecuteCmd(new PhonemePreutterCommand(Part, _activePhoneme.Parent, _activePhoneme.index, newPreutter));
+                if (ViewModel != null)
+                {
+                    ViewModel.EditingTip = $"[{phonemeName}] Preutter: {newPreutter:+0.0;-0.0;0.0} ms";
+                }
                 break;
             case AdvancedHandleType.Overlap:
                 float newOverlap = (float)(_initialDelta + deltaMs);
                 DocManager.Inst.ExecuteCmd(new PhonemeOverlapCommand(Part, _activePhoneme.Parent, _activePhoneme.index, newOverlap));
+                if (ViewModel != null)
+                {
+                    ViewModel.EditingTip = $"[{phonemeName}] Overlap: {newOverlap:+0.0;-0.0;0.0} ms";
+                }
                 break;
         }
 
@@ -424,6 +451,10 @@ public class PhonemeAdvancedCanvas : Control, ICmdSubscriber
             _activePhoneme = null;
             DocManager.Inst.EndUndoGroup();
             e.Pointer.Capture(null);
+            if (ViewModel != null)
+            {
+                ViewModel.EditingTip = string.Empty;
+            }
             InvalidateVisual();
             e.Handled = true;
         }
@@ -441,6 +472,10 @@ public class PhonemeAdvancedCanvas : Control, ICmdSubscriber
             _activeHandleType = AdvancedHandleType.None;
             _activePhoneme = null;
             DocManager.Inst.EndUndoGroup();
+            if (ViewModel != null)
+            {
+                ViewModel.EditingTip = string.Empty;
+            }
             InvalidateVisual();
         }
     }

--- a/OpenUtauMobile/Controls/PhonemeAdvancedCanvas.cs
+++ b/OpenUtauMobile/Controls/PhonemeAdvancedCanvas.cs
@@ -1,0 +1,423 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Media.TextFormatting;
+using OpenUtau.Core;
+using OpenUtau.Core.Ustx;
+using OpenUtauMobile.Themes.OpenUtauMobile.Runtime;
+using OpenUtauMobile.ViewModels;
+
+namespace OpenUtauMobile.Controls;
+
+/// <summary>
+/// 高级音素画布，完全对齐 OpenUtau 桌面端：包络梯形、先行发音（左下角）与重叠（左上角）两处交互控制点。
+/// 顶部留有完整安全边距避开上方分割手柄，双击直接唤起音素别名编辑弹窗。
+/// </summary>
+public class PhonemeAdvancedCanvas : Control, ICmdSubscriber
+{
+    public static readonly StyledProperty<UVoicePart?> PartProperty =
+        AvaloniaProperty.Register<PhonemeAdvancedCanvas, UVoicePart?>(nameof(Part));
+
+    public static readonly StyledProperty<double> TickWidthProperty =
+        AvaloniaProperty.Register<PhonemeAdvancedCanvas, double>(nameof(TickWidth), 0.1);
+
+    public static readonly StyledProperty<double> TickOffsetProperty =
+        AvaloniaProperty.Register<PhonemeAdvancedCanvas, double>(nameof(TickOffset));
+
+    public UVoicePart? Part
+    {
+        get => GetValue(PartProperty);
+        set => SetValue(PartProperty, value);
+    }
+
+    public double TickWidth
+    {
+        get => GetValue(TickWidthProperty);
+        set => SetValue(TickWidthProperty, value);
+    }
+
+    public double TickOffset
+    {
+        get => GetValue(TickOffsetProperty);
+        set => SetValue(TickOffsetProperty, value);
+    }
+
+    private PianoRollViewModel? ViewModel => DataContext as PianoRollViewModel;
+
+    private enum AdvancedHandleType
+    {
+        None,
+        TimingLine,
+        Preutter,
+        Overlap
+    }
+
+    private AdvancedHandleType _activeHandleType = AdvancedHandleType.None;
+    private UPhoneme? _activePhoneme;
+    private double _dragStartPointerX;
+    private float _initialDelta;
+
+    // 双击检测
+    private DateTime _lastClickTime = DateTime.MinValue;
+    private Point _lastClickPoint;
+    private const double DoubleClickMaxTimeMs = 350;
+    private const double DoubleClickMaxDistance = 24.0;
+    private const double HandleHitRadius = 24.0;
+
+    private const double TopMargin = 16.0;      // 顶部留白避开分割条悬浮手柄
+    private const double LabelHeight = 16.0;    // 标签高度
+    private const double BottomMargin = 8.0;    // 底部留白
+
+    private readonly Geometry _handleGeometry = new EllipseGeometry(new Rect(-3.5, -3.5, 7.0, 7.0));
+
+    public PhonemeAdvancedCanvas()
+    {
+        ClipToBounds = true;
+    }
+
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+        DocManager.Inst.AddSubscriber(this);
+    }
+
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnDetachedFromVisualTree(e);
+        DocManager.Inst.RemoveSubscriber(this);
+    }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+        if (change.Property == PartProperty ||
+            change.Property == TickWidthProperty ||
+            change.Property == TickOffsetProperty)
+        {
+            InvalidateVisual();
+        }
+    }
+
+    public override void Render(DrawingContext context)
+    {
+        base.Render(context);
+        if (Part == null || Bounds.Width <= 0 || Bounds.Height <= 0 || DocManager.Inst.Project == null)
+        {
+            return;
+        }
+
+        IBrush bgBrush = ThemeResources.GetBrush("Sem.Color.SurfaceContainerLow");
+        context.DrawRectangle(bgBrush, null, new Rect(0, 0, Bounds.Width, Bounds.Height));
+
+        double partPos = Part.position;
+        double viewLeftTick = TickOffset - 480;
+        double viewRightTick = TickOffset + Bounds.Width / TickWidth + 480;
+
+        IBrush defaultBrush = ThemeResources.GetBrush("Sem.Color.SecondaryContainer");
+        IBrush selectedBrush = ThemeResources.GetBrush("Sem.Color.PrimaryContainer");
+        IPen defaultPen = ThemeResources.GetPen("Sem.Color.Secondary", 1.5);
+        IPen selectedPen = ThemeResources.GetPen("Sem.Color.Primary", 1.5);
+        IPen timingPen = ThemeResources.GetPen("Sem.Color.Primary", 1.5);
+        IPen timingThickPen = ThemeResources.GetPen("Sem.Color.Primary", 3.0);
+        IBrush textBgBrush = ThemeResources.GetBrush("Sem.Color.SurfaceContainerHighest");
+        IPen textBorderPen = ThemeResources.GetPen("Sem.Color.OutlineVariant", 1.0);
+        IBrush textBrush = ThemeResources.GetBrush("Sem.Color.OnSurface");
+
+        double totalHeight = Bounds.Height;
+        double labelY = TopMargin + 2.0;
+        double envelopeTopY = TopMargin + LabelHeight + 4.0;
+        double envelopeHeight = Math.Max(20.0, totalHeight - envelopeTopY - BottomMargin);
+
+        foreach (UPhoneme phoneme in Part.phonemes)
+        {
+            if (phoneme.Parent == null || phoneme.Parent.OverlapError)
+            {
+                continue;
+            }
+
+            double phonemeAbsStart = partPos + phoneme.position;
+            double phonemeAbsEnd = partPos + phoneme.End;
+
+            if (phonemeAbsEnd < viewLeftTick || phonemeAbsStart > viewRightTick)
+            {
+                continue;
+            }
+
+            bool isSelected = ViewModel?.SelectedNotes.Contains(phoneme.Parent) ?? false;
+            IPen pen = isSelected ? selectedPen : defaultPen;
+            IBrush fill = isSelected ? selectedBrush : defaultBrush;
+
+            double posX = (phonemeAbsStart - TickOffset) * TickWidth;
+
+            // 1. 绘制包络梯形（5点）
+            if (!phoneme.Error && phoneme.envelope.data.Count >= 5)
+            {
+                double posMs = phoneme.PositionMs;
+                var timeAxis = DocManager.Inst.Project.timeAxis;
+
+                double x0 = (timeAxis.MsPosToTickPos(posMs + phoneme.envelope.data[0].X) - TickOffset) * TickWidth;
+                double y0 = envelopeTopY + (1.0 - phoneme.envelope.data[0].Y / 100.0) * envelopeHeight;
+
+                double x1 = (timeAxis.MsPosToTickPos(posMs + phoneme.envelope.data[1].X) - TickOffset) * TickWidth;
+                double y1 = envelopeTopY + (1.0 - phoneme.envelope.data[1].Y / 100.0) * envelopeHeight;
+
+                double x2 = (timeAxis.MsPosToTickPos(posMs + phoneme.envelope.data[2].X) - TickOffset) * TickWidth;
+                double y2 = envelopeTopY + (1.0 - phoneme.envelope.data[2].Y / 100.0) * envelopeHeight;
+
+                double x3 = (timeAxis.MsPosToTickPos(posMs + phoneme.envelope.data[3].X) - TickOffset) * TickWidth;
+                double y3 = envelopeTopY + (1.0 - phoneme.envelope.data[3].Y / 100.0) * envelopeHeight;
+
+                double x4 = (timeAxis.MsPosToTickPos(posMs + phoneme.envelope.data[4].X) - TickOffset) * TickWidth;
+                double y4 = envelopeTopY + (1.0 - phoneme.envelope.data[4].Y / 100.0) * envelopeHeight;
+
+                Point[] pts =
+                [
+                    new Point(x0, y0),
+                    new Point(x1, y1),
+                    new Point(x2, y2),
+                    new Point(x3, y3),
+                    new Point(x4, y4)
+                ];
+
+                PolylineGeometry polyline = new PolylineGeometry(pts, true);
+                using (context.PushOpacity(0.40))
+                {
+                    context.DrawGeometry(fill, pen, polyline);
+                }
+
+                // 2. 绘制控制手柄（对齐 OpenUtau 桌面端：左下角先行发音点 + 左上角重叠点）
+                // 控制点 0：先行发音（Preutter - 左下角）
+                IBrush p0Brush = phoneme.preutterDelta.HasValue ? (pen.Brush ?? selectedBrush) : textBgBrush;
+                using (context.PushTransform(Matrix.CreateTranslation(x0, y0)))
+                {
+                    context.DrawGeometry(p0Brush, pen, _handleGeometry);
+                }
+
+                // 控制点 1：重叠（Overlap - 左上角起振过渡点）
+                IBrush p1Brush = phoneme.overlapDelta.HasValue ? (pen.Brush ?? selectedBrush) : textBgBrush;
+                using (context.PushTransform(Matrix.CreateTranslation(x1, y1)))
+                {
+                    context.DrawGeometry(p1Brush, pen, _handleGeometry);
+                }
+            }
+
+            // 3. 绘制垂直位置基准线
+            IPen linePen = phoneme.rawPosition != phoneme.position ? timingThickPen : timingPen;
+            context.DrawLine(linePen, new Point(posX, TopMargin + 2), new Point(posX, envelopeTopY + envelopeHeight + 2));
+
+            // 4. 绘制音素标签药丸框（置于顶部留白下方）
+            string labelText = !string.IsNullOrEmpty(phoneme.phonemeMapped) ? phoneme.phonemeMapped : phoneme.phoneme;
+            if (!string.IsNullOrEmpty(labelText))
+            {
+                bool isCustom = phoneme.phoneme != phoneme.rawPhoneme;
+                TextLayout textLayout = TextLayoutCache.Get(labelText, textBrush, 11, isCustom);
+                double pillWidth = textLayout.Width + 8.0;
+                double pillHeight = textLayout.Height + 2.0;
+                double pillX = posX + 2.0;
+
+                Rect pillRect = new Rect(pillX, labelY, pillWidth, pillHeight);
+                context.DrawRectangle(textBgBrush, textBorderPen, pillRect, 3, 3);
+                using (context.PushTransform(Matrix.CreateTranslation(pillX + 4.0, labelY + 1.0)))
+                {
+                    textLayout.Draw(context, new Point(0, 0));
+                }
+            }
+        }
+    }
+
+    protected override void OnPointerPressed(PointerPressedEventArgs e)
+    {
+        base.OnPointerPressed(e);
+        if (Part == null || DocManager.Inst.Project == null)
+        {
+            return;
+        }
+
+        Point pos = e.GetPosition(this);
+        double partPos = Part.position;
+        double currentTick = pos.X / TickWidth + TickOffset - partPos;
+
+        // 1. 测试是否击中控制手柄
+        (AdvancedHandleType hitType, UPhoneme? hitPhoneme) = HitTestHandle(pos);
+        if (hitType != AdvancedHandleType.None && hitPhoneme != null)
+        {
+            _activeHandleType = hitType;
+            _activePhoneme = hitPhoneme;
+            _dragStartPointerX = pos.X;
+            UPhonemeOverride overrideData = hitPhoneme.Parent.GetPhonemeOverride(hitPhoneme.index);
+
+            _initialDelta = hitType switch
+            {
+                AdvancedHandleType.TimingLine => overrideData.offset ?? 0,
+                AdvancedHandleType.Preutter => overrideData.preutterDelta ?? 0,
+                AdvancedHandleType.Overlap => overrideData.overlapDelta ?? 0,
+                _ => 0
+            };
+
+            e.Pointer.Capture(this);
+            e.Handled = true;
+            DocManager.Inst.StartUndoGroup();
+            return;
+        }
+
+        // 2. 双击检测：打开音素别名编辑弹窗
+        DateTime now = DateTime.UtcNow;
+        double elapsedMs = (now - _lastClickTime).TotalMilliseconds;
+        double dist = Math.Abs(pos.X - _lastClickPoint.X) + Math.Abs(pos.Y - _lastClickPoint.Y);
+
+        if (elapsedMs < DoubleClickMaxTimeMs && dist < DoubleClickMaxDistance)
+        {
+            UPhoneme? clickedPhoneme = FindPhonemeAtTick(currentTick);
+            if (clickedPhoneme != null && clickedPhoneme.Parent != null)
+            {
+                ViewModel?.RaiseRequestEditPhoneme(Part, clickedPhoneme.Parent, clickedPhoneme.index);
+                e.Handled = true;
+                _lastClickTime = DateTime.MinValue;
+                return;
+            }
+        }
+
+        _lastClickTime = now;
+        _lastClickPoint = pos;
+    }
+
+    protected override void OnPointerMoved(PointerEventArgs e)
+    {
+        base.OnPointerMoved(e);
+        if (_activeHandleType == AdvancedHandleType.None || _activePhoneme == null || Part == null || DocManager.Inst.Project == null)
+        {
+            return;
+        }
+
+        Point pos = e.GetPosition(this);
+        double deltaPx = pos.X - _dragStartPointerX;
+        double deltaTicks = deltaPx / TickWidth;
+        double deltaMs = DocManager.Inst.Project.timeAxis.TickPosToMsPos(Part.position + _activePhoneme.position + (int)deltaTicks)
+                       - DocManager.Inst.Project.timeAxis.TickPosToMsPos(Part.position + _activePhoneme.position);
+
+        switch (_activeHandleType)
+        {
+            case AdvancedHandleType.TimingLine:
+                int newOffset = (int)(_initialDelta + deltaTicks);
+                DocManager.Inst.ExecuteCmd(new PhonemeOffsetCommand(Part, _activePhoneme.Parent, _activePhoneme.index, newOffset));
+                break;
+            case AdvancedHandleType.Preutter:
+                float newPreutter = (float)(_initialDelta - deltaMs);
+                DocManager.Inst.ExecuteCmd(new PhonemePreutterCommand(Part, _activePhoneme.Parent, _activePhoneme.index, newPreutter));
+                break;
+            case AdvancedHandleType.Overlap:
+                float newOverlap = (float)(_initialDelta + deltaMs);
+                DocManager.Inst.ExecuteCmd(new PhonemeOverlapCommand(Part, _activePhoneme.Parent, _activePhoneme.index, newOverlap));
+                break;
+        }
+
+        InvalidateVisual();
+        e.Handled = true;
+    }
+
+    protected override void OnPointerReleased(PointerReleasedEventArgs e)
+    {
+        base.OnPointerReleased(e);
+        if (_activeHandleType != AdvancedHandleType.None)
+        {
+            _activeHandleType = AdvancedHandleType.None;
+            _activePhoneme = null;
+            DocManager.Inst.EndUndoGroup();
+            e.Pointer.Capture(null);
+            InvalidateVisual();
+            e.Handled = true;
+        }
+    }
+
+    protected override void OnPointerCaptureLost(PointerCaptureLostEventArgs e)
+    {
+        base.OnPointerCaptureLost(e);
+        if (_activeHandleType != AdvancedHandleType.None)
+        {
+            _activeHandleType = AdvancedHandleType.None;
+            _activePhoneme = null;
+            DocManager.Inst.EndUndoGroup();
+            InvalidateVisual();
+        }
+    }
+
+    private (AdvancedHandleType, UPhoneme?) HitTestHandle(Point pointerPos)
+    {
+        if (Part == null || DocManager.Inst.Project == null)
+        {
+            return (AdvancedHandleType.None, null);
+        }
+
+        double totalHeight = Bounds.Height;
+        double envelopeTopY = TopMargin + LabelHeight + 4.0;
+        double envelopeHeight = Math.Max(20.0, totalHeight - envelopeTopY - BottomMargin);
+        var timeAxis = DocManager.Inst.Project.timeAxis;
+
+        foreach (UPhoneme phoneme in Part.phonemes)
+        {
+            if (phoneme.Parent == null || phoneme.Error || phoneme.envelope.data.Count < 5)
+            {
+                continue;
+            }
+
+            double posMs = phoneme.PositionMs;
+
+            // 点 0：Preutter (左下角)
+            double x0 = (timeAxis.MsPosToTickPos(posMs + phoneme.envelope.data[0].X) - TickOffset) * TickWidth;
+            double y0 = envelopeTopY + (1.0 - phoneme.envelope.data[0].Y / 100.0) * envelopeHeight;
+            if (Math.Abs(pointerPos.X - x0) <= HandleHitRadius && Math.Abs(pointerPos.Y - y0) <= HandleHitRadius)
+            {
+                return (AdvancedHandleType.Preutter, phoneme);
+            }
+
+            // 点 1：Overlap (左上角起振点)
+            double x1 = (timeAxis.MsPosToTickPos(posMs + phoneme.envelope.data[1].X) - TickOffset) * TickWidth;
+            double y1 = envelopeTopY + (1.0 - phoneme.envelope.data[1].Y / 100.0) * envelopeHeight;
+            if (Math.Abs(pointerPos.X - x1) <= HandleHitRadius && Math.Abs(pointerPos.Y - y1) <= HandleHitRadius)
+            {
+                return (AdvancedHandleType.Overlap, phoneme);
+            }
+
+            // 位置基准线
+            double posX = (Part.position + phoneme.position - TickOffset) * TickWidth;
+            if (Math.Abs(pointerPos.X - posX) <= HandleHitRadius * 0.75 && pointerPos.Y >= TopMargin && pointerPos.Y <= envelopeTopY + envelopeHeight + 6)
+            {
+                return (AdvancedHandleType.TimingLine, phoneme);
+            }
+        }
+
+        return (AdvancedHandleType.None, null);
+    }
+
+    private UPhoneme? FindPhonemeAtTick(double partRelativeTick)
+    {
+        if (Part == null)
+        {
+            return null;
+        }
+
+        foreach (UPhoneme phoneme in Part.phonemes)
+        {
+            if (partRelativeTick >= phoneme.position && partRelativeTick <= phoneme.End)
+            {
+                return phoneme;
+            }
+        }
+        return null;
+    }
+
+    public void OnNext(UCommand cmd, bool isUndo)
+    {
+        switch (cmd)
+        {
+            case NoteCommand:
+            case PartCommand:
+            case PhonemizedNotification:
+            case ExpCommand:
+                InvalidateVisual();
+                break;
+        }
+    }
+}

--- a/OpenUtauMobile/Controls/PhonemeEditPopup.axaml
+++ b/OpenUtauMobile/Controls/PhonemeEditPopup.axaml
@@ -1,0 +1,90 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:OpenUtauMobile.ViewModels"
+             mc:Ignorable="d"
+             x:Class="OpenUtauMobile.Controls.PhonemeEditPopup"
+             d:DataContext="{d:DesignInstance Type=vm:PhonemeEditViewModel, IsDesignTimeCreatable=False}"
+             x:DataType="vm:PhonemeEditViewModel"
+             Classes="PopupDialogRoot"
+             MinHeight="180">
+
+    <Border Classes="PopupDialogSurface">
+        <DockPanel>
+            <!-- 标题栏 -->
+            <Border Classes="PopupTitleBar"
+                    DockPanel.Dock="Top">
+                <Grid ColumnDefinitions="*,Auto">
+                    <TextBlock Grid.Column="0"
+                               Text="{DynamicResource PhonemeEdit.Title}"
+                               Classes="PopupTitle" />
+                    <Button Grid.Column="1"
+                            Classes="PopupCloseBtn"
+                            Command="{Binding CancelCommand}"
+                            ToolTip.Tip="{DynamicResource Common.Cancel}">
+                        <Path Width="14" Height="14"
+                              Stretch="Uniform"
+                              Fill="{DynamicResource Sem.Color.OnSurface}"
+                              Data="M19,6.41 L17.59,5 L12,10.59 L6.41,5 L5,6.41 L10.59,12 L5,17.59 L6.41,19 L12,13.41 L17.59,19 L19,17.59 L13.41,12 Z" />
+                    </Button>
+                </Grid>
+            </Border>
+
+            <!-- 内容区域 -->
+            <Border DockPanel.Dock="Top"
+                    Padding="16,16"
+                    Background="{DynamicResource Sem.Color.Surface}">
+                <StackPanel Spacing="12">
+                    <!-- 当前音素信息与恢复默认操作 -->
+                    <Grid ColumnDefinitions="*,Auto" VerticalAlignment="Center">
+                        <StackPanel Grid.Column="0" Orientation="Vertical" Spacing="2">
+                            <TextBlock Text="{Binding CurrentPhonemeInfo}"
+                                       FontSize="13"
+                                       FontWeight="SemiBold"
+                                       Foreground="{DynamicResource Sem.Color.OnSurface}" />
+                            <TextBlock Text="{Binding RawPhonemeHint}"
+                                       FontSize="11"
+                                       Foreground="{DynamicResource Sem.Color.OnSurfaceVariant}" />
+                        </StackPanel>
+                        <Button Grid.Column="1"
+                                Command="{Binding ResetCommand}"
+                                Classes="Secondary"
+                                Padding="8,4"
+                                FontSize="12"
+                                VerticalAlignment="Center"
+                                Content="{DynamicResource PhonemeEdit.Reset}" />
+                    </Grid>
+
+                    <!-- 音素别名输入框 -->
+                    <TextBox x:Name="PhonemeAliasInput"
+                             Text="{Binding CurrentAlias}"
+                             PlaceholderText="{DynamicResource PhonemeEdit.Watermark}"
+                             Padding="12,8"
+                             CornerRadius="8"
+                             FontSize="14"
+                             BorderThickness="1" />
+
+                    <!-- 按钮栏（与歌词编辑完全一致的 3 个按钮） -->
+                    <Grid ColumnDefinitions="*,Auto,Auto,Auto" ColumnSpacing="8">
+                        <Button Grid.Column="1"
+                                Command="{Binding CancelCommand}"
+                                Classes="Secondary"
+                                Content="{DynamicResource Common.Cancel}" />
+
+                        <Button Grid.Column="2"
+                                Command="{Binding NextCommand}"
+                                Classes="Secondary"
+                                Content="{DynamicResource Common.Next}" />
+
+                        <Button Grid.Column="3"
+                                Command="{Binding ConfirmCommand}"
+                                Classes="Primary"
+                                Content="{DynamicResource Common.Confirm}" />
+                    </Grid>
+                </StackPanel>
+            </Border>
+        </DockPanel>
+    </Border>
+
+</UserControl>

--- a/OpenUtauMobile/Controls/PhonemeEditPopup.axaml.cs
+++ b/OpenUtauMobile/Controls/PhonemeEditPopup.axaml.cs
@@ -1,0 +1,46 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Threading;
+using OpenUtauMobile.ViewModels;
+
+namespace OpenUtauMobile.Controls;
+
+public partial class PhonemeEditPopup : UserControl
+{
+    public PhonemeEditPopup()
+    {
+        InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+    }
+
+    private void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        if (DataContext is PhonemeEditViewModel vm)
+        {
+            vm.FocusRequested += FocusInput;
+            Dispatcher.UIThread.Post(FocusInput, DispatcherPriority.Loaded);
+        }
+    }
+
+    private void FocusInput()
+    {
+        PhonemeAliasInput.Focus();
+        PhonemeAliasInput.SelectAll();
+    }
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        if (e.Key == Key.Enter && DataContext is PhonemeEditViewModel vm)
+        {
+            vm.ConfirmCommand.Execute().Subscribe();
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Escape && DataContext is PhonemeEditViewModel vmEscape)
+        {
+            vmEscape.CancelCommand.Execute().Subscribe();
+            e.Handled = true;
+        }
+    }
+}

--- a/OpenUtauMobile/Controls/PhonemePanelModeSwitcher.axaml
+++ b/OpenUtauMobile/Controls/PhonemePanelModeSwitcher.axaml
@@ -1,0 +1,67 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:iconPacks="https://github.com/MahApps/IconPacks.Avalonia"
+             xmlns:openUtauMobile="clr-namespace:OpenUtauMobile"
+             xmlns:theme="clr-namespace:OpenUtauMobile.Themes.OpenUtauMobile.Runtime"
+             x:Class="OpenUtauMobile.Controls.PhonemePanelModeSwitcher"
+             HorizontalAlignment="Right">
+
+    <Border x:Name="Capsule"
+            Background="{DynamicResource Sem.Color.SurfaceContainer}"
+            CornerRadius="{x:Static theme:ThemeBaseShapeTokens.CornerXL}"
+            Height="{x:Static theme:ThemeBaseLayoutTokens.SizeM}"
+            ClipToBounds="True"
+            HorizontalAlignment="Right">
+        <Grid ColumnDefinitions="Auto,Auto"
+              VerticalAlignment="Center"
+              HorizontalAlignment="Right">
+            <!-- 展开的编辑模式按钮列表（向左展开） -->
+            <Grid Grid.Column="0"
+                  x:Name="ModeButtonsGrid"
+                  ColumnDefinitions="Auto,Auto"
+                  VerticalAlignment="Center"
+                  ClipToBounds="True">
+                <Grid.Transitions>
+                    <Transitions>
+                        <DoubleTransition Property="Width" Duration="{x:Static theme:ThemeBaseMotionTokens.DurationBase}" Easing="CubicEaseOut" />
+                    </Transitions>
+                </Grid.Transitions>
+                <StackPanel Grid.Column="0"
+                            x:Name="ModeButtonsPanel"
+                            Orientation="Horizontal"
+                            Spacing="{x:Static openUtauMobile:ViewConstants.EditModeItemSpacing}">
+                    <Button Content="{iconPacks:PhosphorIcons Rows}"
+                            Classes="EditModeBtn"
+                            x:Name="PhonemeSimpleButton"
+                            ToolTip.Tip="{DynamicResource PhonemePanel.Mode.Simple}"
+                            Click="OnModeButtonClick" />
+                    <Button Content="{iconPacks:PhosphorIcons WaveTriangle}"
+                            Classes="EditModeBtn"
+                            x:Name="PhonemeAdvancedButton"
+                            ToolTip.Tip="{DynamicResource PhonemePanel.Mode.Advanced}"
+                            Click="OnModeButtonClick" />
+                    <Button Content="{iconPacks:PhosphorIcons Pencil}"
+                            Classes="EditModeBtn"
+                            x:Name="ParameterDrawButton"
+                            ToolTip.Tip="{DynamicResource PhonemePanel.Mode.Draw}"
+                            Click="OnModeButtonClick" />
+                    <Button Content="{iconPacks:PhosphorIcons Eraser}"
+                            Classes="EditModeBtn"
+                            x:Name="ParameterEraseButton"
+                            ToolTip.Tip="{DynamicResource PhonemePanel.Mode.Erase}"
+                            Click="OnModeButtonClick" />
+                    <!-- 分隔线 -->
+                    <Border Width="1"
+                            Background="{DynamicResource Sem.Color.Outline}" />
+                </StackPanel>
+            </Grid>
+            <!-- 当前编辑模式按钮（右侧固定显示） -->
+            <Button Grid.Column="1"
+                    x:Name="SwitchButton"
+                    Classes="EditModeBtn"
+                    Click="OnSwitchButtonClick"
+                    ToolTip.Tip="{DynamicResource PhonemePanel.EditMode.Switch}">
+            </Button>
+        </Grid>
+    </Border>
+</UserControl>

--- a/OpenUtauMobile/Controls/PhonemePanelModeSwitcher.axaml.cs
+++ b/OpenUtauMobile/Controls/PhonemePanelModeSwitcher.axaml.cs
@@ -1,0 +1,135 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using IconPacks.Avalonia.PhosphorIcons;
+using OpenUtauMobile.Themes.OpenUtauMobile.Runtime;
+using OpenUtauMobile.ViewModels;
+
+namespace OpenUtauMobile.Controls;
+
+public partial class PhonemePanelModeSwitcher : UserControl
+{
+    // 依赖属性：当前面板编辑模式
+    public static readonly StyledProperty<PhonemePanelMode> CurrentModeProperty =
+        AvaloniaProperty.Register<PhonemePanelModeSwitcher, PhonemePanelMode>(
+            nameof(CurrentMode),
+            defaultBindingMode: BindingMode.TwoWay);
+
+    public PhonemePanelMode CurrentMode
+    {
+        get => GetValue(CurrentModeProperty);
+        set => SetValue(CurrentModeProperty, value);
+    }
+
+    private bool _isExpand;
+
+    public PhonemePanelModeSwitcher()
+    {
+        InitializeComponent();
+        UpdateCurrentModeVisualState();
+        UpdateExpandVisualState();
+    }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+        if (change.Property == CurrentModeProperty)
+        {
+            _isExpand = false;
+            UpdateExpandVisualState();
+            UpdateCurrentModeVisualState();
+        }
+    }
+
+    private void UpdateCurrentModeVisualState()
+    {
+        IBrush selectedBrush = ThemeResources.GetBrush("Sem.Color.PrimaryContainer");
+        ResetModeListVisualState();
+        switch (CurrentMode)
+        {
+            case PhonemePanelMode.PhonemeSimple:
+                PhonemeSimpleButton.Background = selectedBrush;
+                SwitchButton.Content = new PackIconPhosphorIcons
+                {
+                    Kind = PackIconPhosphorIconsKind.Rows
+                };
+                break;
+            case PhonemePanelMode.PhonemeAdvanced:
+                PhonemeAdvancedButton.Background = selectedBrush;
+                SwitchButton.Content = new PackIconPhosphorIcons
+                {
+                    Kind = PackIconPhosphorIconsKind.WaveTriangle
+                };
+                break;
+            case PhonemePanelMode.ParameterDraw:
+                ParameterDrawButton.Background = selectedBrush;
+                SwitchButton.Content = new PackIconPhosphorIcons
+                {
+                    Kind = PackIconPhosphorIconsKind.Pencil
+                };
+                break;
+            case PhonemePanelMode.ParameterErase:
+                ParameterEraseButton.Background = selectedBrush;
+                SwitchButton.Content = new PackIconPhosphorIcons
+                {
+                    Kind = PackIconPhosphorIconsKind.Eraser
+                };
+                break;
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+    }
+
+    private void OnSwitchButtonClick(object? sender, RoutedEventArgs e)
+    {
+        _isExpand = !_isExpand;
+        UpdateExpandVisualState();
+    }
+
+    private void OnModeButtonClick(object? sender, RoutedEventArgs e)
+    {
+        if (ReferenceEquals(sender, PhonemeSimpleButton))
+        {
+            CurrentMode = PhonemePanelMode.PhonemeSimple;
+        }
+        else if (ReferenceEquals(sender, PhonemeAdvancedButton))
+        {
+            CurrentMode = PhonemePanelMode.PhonemeAdvanced;
+        }
+        else if (ReferenceEquals(sender, ParameterDrawButton))
+        {
+            CurrentMode = PhonemePanelMode.ParameterDraw;
+        }
+        else if (ReferenceEquals(sender, ParameterEraseButton))
+        {
+            CurrentMode = PhonemePanelMode.ParameterErase;
+        }
+
+        UpdateCurrentModeVisualState();
+    }
+
+    private void ResetModeListVisualState()
+    {
+        IImmutableSolidColorBrush backgroundBrush = Brushes.Transparent;
+        PhonemeSimpleButton.Background = backgroundBrush;
+        PhonemeAdvancedButton.Background = backgroundBrush;
+        ParameterDrawButton.Background = backgroundBrush;
+        ParameterEraseButton.Background = backgroundBrush;
+    }
+
+    private void UpdateExpandVisualState()
+    {
+        if (_isExpand)
+        {
+            double width = ModeButtonsPanel.DesiredSize.Width;
+            ModeButtonsGrid.Width = width;
+        }
+        else
+        {
+            ModeButtonsGrid.Width = 0;
+        }
+    }
+}

--- a/OpenUtauMobile/Controls/PhonemeParamPanel.axaml
+++ b/OpenUtauMobile/Controls/PhonemeParamPanel.axaml
@@ -1,0 +1,66 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:c="clr-namespace:OpenUtauMobile.Controls"
+             xmlns:vm="clr-namespace:OpenUtauMobile.ViewModels"
+             xmlns:local="clr-namespace:OpenUtauMobile"
+             xmlns:tools="clr-namespace:OpenUtauMobile.Tools"
+             xmlns:theme="clr-namespace:OpenUtauMobile.Themes.OpenUtauMobile.Runtime"
+             x:Class="OpenUtauMobile.Controls.PhonemeParamPanel"
+             x:DataType="vm:PianoRollViewModel">
+
+    <UserControl.Resources>
+        <tools:DoubleToGridLengthConverter x:Key="DoubleToGridLengthConverter" />
+    </UserControl.Resources>
+
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="{Binding Source={x:Static local:ViewConstants.PianoKeysWidth}, Converter={StaticResource DoubleToGridLengthConverter}}" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+
+        <!-- 左侧工具栏列（与上方钢琴键宽度对齐） -->
+        <Border Grid.Column="0"
+                Background="{DynamicResource Sem.Color.SurfaceContainer}"
+                BorderBrush="{DynamicResource Sem.Color.OutlineVariant}"
+                BorderThickness="0,0,1,0">
+            <c:ParameterPanelToolbar IsVisible="{Binding IsParameterMode}"
+                                     HorizontalAlignment="Stretch"
+                                     VerticalAlignment="Stretch" />
+        </Border>
+
+        <!-- 右侧画布区 -->
+        <Panel Grid.Column="1" ClipToBounds="True">
+            <!-- 简易音素画布 -->
+            <c:PhonemeSimpleCanvas
+                IsVisible="{Binding IsPhonemeSimpleMode}"
+                Part="{Binding EditingVoicePart}"
+                TickWidth="{Binding TickWidth}"
+                TickOffset="{Binding TickOffset}" />
+
+            <!-- 高级音素画布 -->
+            <c:PhonemeAdvancedCanvas
+                IsVisible="{Binding IsPhonemeAdvancedMode}"
+                Part="{Binding EditingVoicePart}"
+                TickWidth="{Binding TickWidth}"
+                TickOffset="{Binding TickOffset}" />
+
+            <!-- 参数曲线/表情画布 -->
+            <c:ParameterCanvas
+                IsVisible="{Binding IsParameterMode}"
+                Part="{Binding EditingVoicePart}"
+                TickWidth="{Binding TickWidth}"
+                TickOffset="{Binding TickOffset}"
+                PrimaryKey="{Binding PrimaryExpressionKey}"
+                SecondaryKey="{Binding SecondaryExpressionKey}"
+                IsEraseMode="{Binding IsParameterEraseMode}" />
+
+            <!-- 右下角悬浮模式切换胶囊（彻底与上方分割条手柄隔离） -->
+            <c:PhonemePanelModeSwitcher
+                ZIndex="10"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Bottom"
+                Margin="0,0,10,10"
+                CurrentMode="{Binding PhonemePanelMode, Mode=TwoWay}" />
+        </Panel>
+    </Grid>
+</UserControl>

--- a/OpenUtauMobile/Controls/PhonemeParamPanel.axaml
+++ b/OpenUtauMobile/Controls/PhonemeParamPanel.axaml
@@ -54,12 +54,12 @@
                 SecondaryKey="{Binding SecondaryExpressionKey}"
                 IsEraseMode="{Binding IsParameterEraseMode}" />
 
-            <!-- 右下角悬浮模式切换胶囊（彻底与上方分割条手柄隔离） -->
+            <!-- 右上角悬浮模式切换胶囊（留有顶部安全边距避开上方分割手柄） -->
             <c:PhonemePanelModeSwitcher
                 ZIndex="10"
                 HorizontalAlignment="Right"
-                VerticalAlignment="Bottom"
-                Margin="0,0,10,10"
+                VerticalAlignment="Top"
+                Margin="0,16,10,0"
                 CurrentMode="{Binding PhonemePanelMode, Mode=TwoWay}" />
         </Panel>
     </Grid>

--- a/OpenUtauMobile/Controls/PhonemeParamPanel.axaml.cs
+++ b/OpenUtauMobile/Controls/PhonemeParamPanel.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace OpenUtauMobile.Controls;
+
+public partial class PhonemeParamPanel : UserControl
+{
+    public PhonemeParamPanel()
+    {
+        InitializeComponent();
+    }
+}

--- a/OpenUtauMobile/Controls/PhonemeSimpleCanvas.cs
+++ b/OpenUtauMobile/Controls/PhonemeSimpleCanvas.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media;
 using Avalonia.Media.TextFormatting;
+using Avalonia.Threading;
 using OpenUtau.Core;
 using OpenUtau.Core.Ustx;
 using OpenUtauMobile.Themes.OpenUtauMobile.Runtime;
@@ -44,14 +45,24 @@ public class PhonemeSimpleCanvas : Control, ICmdSubscriber
         set => SetValue(TickOffsetProperty, value);
     }
 
-    private PianoRollViewModel? ViewModel => DataContext as PianoRollViewModel;
+    private PianoRollViewModel? _viewModel;
+    private PianoRollViewModel? ViewModel => _viewModel ?? (DataContext as PianoRollViewModel);
 
     // 拖拽与双击状态
     private bool _isDraggingBoundary;
     private UPhoneme? _draggingPhoneme;
+    private UPhoneme? _animatingPhoneme;
     private double _dragStartPointerX;
     private int _dragInitialOffset;
     private int _lastPushedOffset;
+
+    // 手柄展开动效状态
+    private DispatcherTimer? _animTimer;
+    private double _animProgress;
+    private double _animStartProgress;
+    private double _animTargetProgress;
+    private DateTime _animStartTime;
+    private const double AnimDurationMs = 130.0;
 
     private DateTime _lastClickTime = DateTime.MinValue;
     private Point _lastClickPoint;
@@ -65,16 +76,82 @@ public class PhonemeSimpleCanvas : Control, ICmdSubscriber
         ClipToBounds = true;
     }
 
+    private void StartDragAnimation(double target)
+    {
+        _animStartProgress = _animProgress;
+        _animTargetProgress = target;
+        _animStartTime = DateTime.UtcNow;
+
+        if (_animTimer == null)
+        {
+            _animTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(16) };
+            _animTimer.Tick += OnAnimTimerTick;
+        }
+        _animTimer.Start();
+    }
+
+    private void OnAnimTimerTick(object? sender, EventArgs e)
+    {
+        double elapsed = (DateTime.UtcNow - _animStartTime).TotalMilliseconds;
+        double t = Math.Clamp(elapsed / AnimDurationMs, 0.0, 1.0);
+        // CubicEaseOut
+        double eased = 1.0 - Math.Pow(1.0 - t, 3);
+        _animProgress = _animStartProgress + (_animTargetProgress - _animStartProgress) * eased;
+
+        InvalidateVisual();
+
+        if (t >= 1.0)
+        {
+            _animProgress = _animTargetProgress;
+            _animTimer?.Stop();
+            if (_animProgress <= 0.0 && !_isDraggingBoundary)
+            {
+                _animatingPhoneme = null;
+            }
+        }
+    }
+
+    protected override void OnDataContextChanged(EventArgs e)
+    {
+        base.OnDataContextChanged(e);
+        if (_viewModel != null)
+        {
+            _viewModel.RequestInvalidateVisual -= InvalidateVisual;
+        }
+
+        _viewModel = DataContext as PianoRollViewModel;
+
+        if (_viewModel != null)
+        {
+            _viewModel.RequestInvalidateVisual += InvalidateVisual;
+        }
+    }
+
     protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
     {
         base.OnAttachedToVisualTree(e);
         DocManager.Inst.AddSubscriber(this);
+        if (DataContext is PianoRollViewModel vm)
+        {
+            if (_viewModel != null)
+            {
+                _viewModel.RequestInvalidateVisual -= InvalidateVisual;
+            }
+            _viewModel = vm;
+            _viewModel.RequestInvalidateVisual += InvalidateVisual;
+        }
     }
 
     protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
     {
         base.OnDetachedFromVisualTree(e);
         DocManager.Inst.RemoveSubscriber(this);
+        _animTimer?.Stop();
+        if (_viewModel != null)
+        {
+            _viewModel.RequestInvalidateVisual -= InvalidateVisual;
+            _viewModel = null;
+        }
     }
 
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
@@ -111,7 +188,6 @@ public class PhonemeSimpleCanvas : Control, ICmdSubscriber
 
         IBrush boundaryDefaultBrush = ThemeResources.GetBrush("Sem.Color.Outline");
         IBrush boundaryActiveBrush = ThemeResources.GetBrush("Sem.Color.Primary");
-        IPen boundaryIndicatorPen = ThemeResources.GetPen("Sem.Color.Primary", 2.0);
 
         double canvasHeight = Bounds.Height;
         // 顶部预留 14dp 空隙避开上方悬浮的分割条胶囊手柄，底部预留 6dp
@@ -181,21 +257,19 @@ public class PhonemeSimpleCanvas : Control, ICmdSubscriber
 
             // 3. 绘制卡片之间的垂直边界手柄条（居中在卡片间隙）
             bool isModified = phoneme.rawPosition != phoneme.position;
-            double handleWidth = isModified ? 3.5 : 2.5;
-            IBrush handleBrush = isModified ? boundaryActiveBrush : boundaryDefaultBrush;
+            bool isAnimTarget = _animatingPhoneme == phoneme && _animProgress > 0.001;
+            double progress = isAnimTarget ? _animProgress : 0.0;
+
+            double expansion = 5.0 * progress; // 拖拽时平滑上下延伸 5dp，适度突出于卡片
+            double widthBonus = 1.2 * progress;
+            double handleWidth = (isModified ? 3.5 : 2.5) + widthBonus;
+            IBrush handleBrush = (isModified || progress > 0.001) ? boundaryActiveBrush : boundaryDefaultBrush;
             double handleX = x1 - handleWidth * 0.5;
-            double handleY = topMargin + 2.0;
-            double handleH = Math.Max(4.0, blockHeight - 4.0);
+            double handleY = topMargin + 2.0 - expansion;
+            double handleH = Math.Max(4.0, blockHeight - 4.0) + expansion * 2.0;
 
             Rect handleRect = new Rect(handleX, handleY, handleWidth, handleH);
             context.DrawRectangle(handleBrush, null, handleRect, handleWidth * 0.5, handleWidth * 0.5);
-        }
-
-        // 4. 若正在拖拽边界，绘制全高指示线
-        if (_isDraggingBoundary && _draggingPhoneme != null)
-        {
-            double dragX = (partPos + _draggingPhoneme.position - TickOffset) * TickWidth;
-            context.DrawLine(boundaryIndicatorPen, new Point(dragX, 0), new Point(dragX, Bounds.Height));
         }
     }
 
@@ -217,10 +291,12 @@ public class PhonemeSimpleCanvas : Control, ICmdSubscriber
         {
             _isDraggingBoundary = true;
             _draggingPhoneme = hitBoundaryPhoneme;
+            _animatingPhoneme = hitBoundaryPhoneme;
             _dragStartPointerX = pos.X;
             _dragInitialOffset = hitBoundaryPhoneme.Parent.GetPhonemeOverride(hitBoundaryPhoneme.index).offset ?? 0;
             _lastPushedOffset = _dragInitialOffset;
 
+            StartDragAnimation(1.0);
             e.Pointer.Capture(this);
             e.Handled = true;
             DocManager.Inst.StartUndoGroup();
@@ -277,9 +353,9 @@ public class PhonemeSimpleCanvas : Control, ICmdSubscriber
         {
             _isDraggingBoundary = false;
             _draggingPhoneme = null;
+            StartDragAnimation(0.0);
             DocManager.Inst.EndUndoGroup();
             e.Pointer.Capture(null);
-            InvalidateVisual();
             e.Handled = true;
         }
     }
@@ -291,8 +367,8 @@ public class PhonemeSimpleCanvas : Control, ICmdSubscriber
         {
             _isDraggingBoundary = false;
             _draggingPhoneme = null;
+            StartDragAnimation(0.0);
             DocManager.Inst.EndUndoGroup();
-            InvalidateVisual();
         }
     }
 

--- a/OpenUtauMobile/Controls/PhonemeSimpleCanvas.cs
+++ b/OpenUtauMobile/Controls/PhonemeSimpleCanvas.cs
@@ -300,6 +300,16 @@ public class PhonemeSimpleCanvas : Control, ICmdSubscriber
             e.Pointer.Capture(this);
             e.Handled = true;
             DocManager.Inst.StartUndoGroup();
+
+            string phonemeName = !string.IsNullOrEmpty(hitBoundaryPhoneme.phonemeMapped) ? hitBoundaryPhoneme.phonemeMapped : hitBoundaryPhoneme.phoneme;
+            double offsetMs = DocManager.Inst.Project != null
+                ? DocManager.Inst.Project.timeAxis.TickPosToMsPos(Part.position + hitBoundaryPhoneme.rawPosition + _dragInitialOffset)
+                  - DocManager.Inst.Project.timeAxis.TickPosToMsPos(Part.position + hitBoundaryPhoneme.rawPosition)
+                : 0.0;
+            if (ViewModel != null)
+            {
+                ViewModel.EditingTip = $"[{phonemeName}] Offset: {_dragInitialOffset:+0;-0;0} tick ({offsetMs:+0.0;-0.0;0.0} ms)";
+            }
             return;
         }
 
@@ -343,6 +353,16 @@ public class PhonemeSimpleCanvas : Control, ICmdSubscriber
             DocManager.Inst.ExecuteCmd(new PhonemeOffsetCommand(Part, _draggingPhoneme.Parent, _draggingPhoneme.index, newOffset));
             InvalidateVisual();
         }
+
+        string phonemeName = !string.IsNullOrEmpty(_draggingPhoneme.phonemeMapped) ? _draggingPhoneme.phonemeMapped : _draggingPhoneme.phoneme;
+        double offsetMs = DocManager.Inst.Project != null
+            ? DocManager.Inst.Project.timeAxis.TickPosToMsPos(Part.position + _draggingPhoneme.rawPosition + newOffset)
+              - DocManager.Inst.Project.timeAxis.TickPosToMsPos(Part.position + _draggingPhoneme.rawPosition)
+            : 0.0;
+        if (ViewModel != null)
+        {
+            ViewModel.EditingTip = $"[{phonemeName}] Offset: {newOffset:+0;-0;0} tick ({offsetMs:+0.0;-0.0;0.0} ms)";
+        }
         e.Handled = true;
     }
 
@@ -356,6 +376,10 @@ public class PhonemeSimpleCanvas : Control, ICmdSubscriber
             StartDragAnimation(0.0);
             DocManager.Inst.EndUndoGroup();
             e.Pointer.Capture(null);
+            if (ViewModel != null)
+            {
+                ViewModel.EditingTip = string.Empty;
+            }
             e.Handled = true;
         }
     }
@@ -369,6 +393,10 @@ public class PhonemeSimpleCanvas : Control, ICmdSubscriber
             _draggingPhoneme = null;
             StartDragAnimation(0.0);
             DocManager.Inst.EndUndoGroup();
+            if (ViewModel != null)
+            {
+                ViewModel.EditingTip = string.Empty;
+            }
         }
     }
 

--- a/OpenUtauMobile/Controls/PhonemeSimpleCanvas.cs
+++ b/OpenUtauMobile/Controls/PhonemeSimpleCanvas.cs
@@ -1,0 +1,358 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Media.TextFormatting;
+using OpenUtau.Core;
+using OpenUtau.Core.Ustx;
+using OpenUtauMobile.Themes.OpenUtauMobile.Runtime;
+using OpenUtauMobile.ViewModels;
+
+namespace OpenUtauMobile.Controls;
+
+/// <summary>
+/// 简易音素画布，SynthV 风格：独立的圆角音素卡片，卡片之间有清晰间距与显著的垂直边界手柄。
+/// 双击音素卡片直接唤起音素别名编辑弹窗。
+/// </summary>
+public class PhonemeSimpleCanvas : Control, ICmdSubscriber
+{
+    public static readonly StyledProperty<UVoicePart?> PartProperty =
+        AvaloniaProperty.Register<PhonemeSimpleCanvas, UVoicePart?>(nameof(Part));
+
+    public static readonly StyledProperty<double> TickWidthProperty =
+        AvaloniaProperty.Register<PhonemeSimpleCanvas, double>(nameof(TickWidth), 0.1);
+
+    public static readonly StyledProperty<double> TickOffsetProperty =
+        AvaloniaProperty.Register<PhonemeSimpleCanvas, double>(nameof(TickOffset));
+
+    public UVoicePart? Part
+    {
+        get => GetValue(PartProperty);
+        set => SetValue(PartProperty, value);
+    }
+
+    public double TickWidth
+    {
+        get => GetValue(TickWidthProperty);
+        set => SetValue(TickWidthProperty, value);
+    }
+
+    public double TickOffset
+    {
+        get => GetValue(TickOffsetProperty);
+        set => SetValue(TickOffsetProperty, value);
+    }
+
+    private PianoRollViewModel? ViewModel => DataContext as PianoRollViewModel;
+
+    // 拖拽与双击状态
+    private bool _isDraggingBoundary;
+    private UPhoneme? _draggingPhoneme;
+    private double _dragStartPointerX;
+    private int _dragInitialOffset;
+    private int _lastPushedOffset;
+
+    private DateTime _lastClickTime = DateTime.MinValue;
+    private Point _lastClickPoint;
+    private const double DoubleClickMaxTimeMs = 350;
+    private const double DoubleClickMaxDistance = 24.0;
+    private const double BoundaryHitRadius = 20.0;
+    private const double ChipMargin = 5.0; // 音素卡片与边界手柄之间的水平间隙（卡片之间共留出 10px 间距）
+
+    public PhonemeSimpleCanvas()
+    {
+        ClipToBounds = true;
+    }
+
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+        DocManager.Inst.AddSubscriber(this);
+    }
+
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnDetachedFromVisualTree(e);
+        DocManager.Inst.RemoveSubscriber(this);
+    }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+        if (change.Property == PartProperty ||
+            change.Property == TickWidthProperty ||
+            change.Property == TickOffsetProperty)
+        {
+            InvalidateVisual();
+        }
+    }
+
+    public override void Render(DrawingContext context)
+    {
+        base.Render(context);
+        if (Part == null || Bounds.Width <= 0 || Bounds.Height <= 0)
+        {
+            return;
+        }
+
+        IBrush bgBrush = ThemeResources.GetBrush("Sem.Color.SurfaceContainerLow");
+        context.DrawRectangle(bgBrush, null, new Rect(0, 0, Bounds.Width, Bounds.Height));
+
+        double partPos = Part.position;
+        double viewLeftTick = TickOffset - 480;
+        double viewRightTick = TickOffset + Bounds.Width / TickWidth + 480;
+
+        IBrush defaultChipFill = ThemeResources.GetBrush("Sem.Color.SurfaceContainerHigh");
+        IBrush selectedChipFill = ThemeResources.GetBrush("Sem.Color.PrimaryContainer");
+        IPen chipBorderPen = ThemeResources.GetPen("Sem.Color.OutlineVariant", 1.0);
+        IBrush textBrush = ThemeResources.GetBrush("Sem.Color.OnSurface");
+        IBrush selectedTextBrush = ThemeResources.GetBrush("Sem.Color.OnPrimaryContainer");
+
+        IBrush boundaryDefaultBrush = ThemeResources.GetBrush("Sem.Color.Outline");
+        IBrush boundaryActiveBrush = ThemeResources.GetBrush("Sem.Color.Primary");
+        IPen boundaryIndicatorPen = ThemeResources.GetPen("Sem.Color.Primary", 2.0);
+
+        double canvasHeight = Bounds.Height;
+        // 顶部预留 14dp 空隙避开上方悬浮的分割条胶囊手柄，底部预留 6dp
+        const double topMargin = 14.0;
+        const double bottomMargin = 6.0;
+        double blockHeight = Math.Max(16.0, canvasHeight - topMargin - bottomMargin);
+
+        foreach (UPhoneme phoneme in Part.phonemes)
+        {
+            if (phoneme.Parent == null)
+            {
+                continue;
+            }
+
+            double phonemeAbsStart = partPos + phoneme.position;
+            double phonemeAbsEnd = partPos + phoneme.End;
+
+            if (phonemeAbsEnd < viewLeftTick || phonemeAbsStart > viewRightTick)
+            {
+                continue;
+            }
+
+            double x1 = (phonemeAbsStart - TickOffset) * TickWidth;
+            double x2 = (phonemeAbsEnd - TickOffset) * TickWidth;
+
+            // 卡片左右各留出间隙，让边界手柄位于卡片之间而不是重叠在卡片边框上
+            double totalWidth = x2 - x1;
+            double actualMargin = Math.Min(ChipMargin, Math.Max(1.0, totalWidth * 0.15));
+            double chipLeft = x1 + actualMargin;
+            double chipRight = x2 - actualMargin;
+            double chipWidth = Math.Max(2.0, chipRight - chipLeft);
+
+            bool isSelected = ViewModel?.SelectedNotes.Contains(phoneme.Parent) ?? false;
+            IBrush fillBrush = isSelected ? selectedChipFill : defaultChipFill;
+            IBrush currentTextBrush = isSelected ? selectedTextBrush : textBrush;
+
+            // 1. 绘制音素卡片（SynthV 风格独立圆角药丸框）
+            Rect blockRect = new Rect(chipLeft, topMargin, chipWidth, blockHeight);
+            context.DrawRectangle(fillBrush, chipBorderPen, blockRect, 4, 4);
+
+            // 2. 绘制音素文字
+            string displayText = !string.IsNullOrEmpty(phoneme.phonemeMapped) ? phoneme.phonemeMapped : phoneme.phoneme;
+            if (!string.IsNullOrEmpty(displayText) && chipWidth > 8.0)
+            {
+                bool isCustom = phoneme.phoneme != phoneme.rawPhoneme;
+                TextLayout textLayout = TextLayoutCache.Get(displayText, currentTextBrush, 12, isCustom);
+                if (textLayout.Width <= chipWidth - 4.0)
+                {
+                    double textX = chipLeft + (chipWidth - textLayout.Width) * 0.5;
+                    double textY = topMargin + (blockHeight - textLayout.Height) * 0.5;
+                    using (context.PushTransform(Matrix.CreateTranslation(textX, textY)))
+                    {
+                        textLayout.Draw(context, new Point(0, 0));
+                    }
+                }
+                else
+                {
+                    double textX = chipLeft + 2.0;
+                    double textY = topMargin + (blockHeight - textLayout.Height) * 0.5;
+                    using (context.PushClip(new Rect(chipLeft + 1, topMargin, chipWidth - 2, blockHeight)))
+                    using (context.PushTransform(Matrix.CreateTranslation(textX, textY)))
+                    {
+                        textLayout.Draw(context, new Point(0, 0));
+                    }
+                }
+            }
+
+            // 3. 绘制卡片之间的垂直边界手柄条（居中在卡片间隙）
+            bool isModified = phoneme.rawPosition != phoneme.position;
+            double handleWidth = isModified ? 3.5 : 2.5;
+            IBrush handleBrush = isModified ? boundaryActiveBrush : boundaryDefaultBrush;
+            double handleX = x1 - handleWidth * 0.5;
+            double handleY = topMargin + 2.0;
+            double handleH = Math.Max(4.0, blockHeight - 4.0);
+
+            Rect handleRect = new Rect(handleX, handleY, handleWidth, handleH);
+            context.DrawRectangle(handleBrush, null, handleRect, handleWidth * 0.5, handleWidth * 0.5);
+        }
+
+        // 4. 若正在拖拽边界，绘制全高指示线
+        if (_isDraggingBoundary && _draggingPhoneme != null)
+        {
+            double dragX = (partPos + _draggingPhoneme.position - TickOffset) * TickWidth;
+            context.DrawLine(boundaryIndicatorPen, new Point(dragX, 0), new Point(dragX, Bounds.Height));
+        }
+    }
+
+    protected override void OnPointerPressed(PointerPressedEventArgs e)
+    {
+        base.OnPointerPressed(e);
+        if (Part == null)
+        {
+            return;
+        }
+
+        Point pos = e.GetPosition(this);
+        double partPos = Part.position;
+        double currentTick = pos.X / TickWidth + TickOffset - partPos;
+
+        // 1. 测试是否击中边界手柄（支持滑动调整 timing offset）
+        UPhoneme? hitBoundaryPhoneme = FindPhonemeBoundaryAt(pos.X);
+        if (hitBoundaryPhoneme != null && hitBoundaryPhoneme.Parent != null)
+        {
+            _isDraggingBoundary = true;
+            _draggingPhoneme = hitBoundaryPhoneme;
+            _dragStartPointerX = pos.X;
+            _dragInitialOffset = hitBoundaryPhoneme.Parent.GetPhonemeOverride(hitBoundaryPhoneme.index).offset ?? 0;
+            _lastPushedOffset = _dragInitialOffset;
+
+            e.Pointer.Capture(this);
+            e.Handled = true;
+            DocManager.Inst.StartUndoGroup();
+            return;
+        }
+
+        // 2. 双击检测：打开音素别名编辑弹窗
+        DateTime now = DateTime.UtcNow;
+        double elapsedMs = (now - _lastClickTime).TotalMilliseconds;
+        double dist = Math.Abs(pos.X - _lastClickPoint.X) + Math.Abs(pos.Y - _lastClickPoint.Y);
+
+        if (elapsedMs < DoubleClickMaxTimeMs && dist < DoubleClickMaxDistance)
+        {
+            UPhoneme? hitPhoneme = FindPhonemeAtTick(currentTick);
+            if (hitPhoneme != null && hitPhoneme.Parent != null)
+            {
+                ViewModel?.RaiseRequestEditPhoneme(Part, hitPhoneme.Parent, hitPhoneme.index);
+                e.Handled = true;
+                _lastClickTime = DateTime.MinValue;
+                return;
+            }
+        }
+
+        _lastClickTime = now;
+        _lastClickPoint = pos;
+    }
+
+    protected override void OnPointerMoved(PointerEventArgs e)
+    {
+        base.OnPointerMoved(e);
+        if (!_isDraggingBoundary || _draggingPhoneme == null || Part == null)
+        {
+            return;
+        }
+
+        Point pos = e.GetPosition(this);
+        double deltaPx = pos.X - _dragStartPointerX;
+        int deltaTicks = (int)Math.Round(deltaPx / TickWidth);
+        int newOffset = _dragInitialOffset + deltaTicks;
+
+        if (newOffset != _lastPushedOffset)
+        {
+            _lastPushedOffset = newOffset;
+            DocManager.Inst.ExecuteCmd(new PhonemeOffsetCommand(Part, _draggingPhoneme.Parent, _draggingPhoneme.index, newOffset));
+            InvalidateVisual();
+        }
+        e.Handled = true;
+    }
+
+    protected override void OnPointerReleased(PointerReleasedEventArgs e)
+    {
+        base.OnPointerReleased(e);
+        if (_isDraggingBoundary)
+        {
+            _isDraggingBoundary = false;
+            _draggingPhoneme = null;
+            DocManager.Inst.EndUndoGroup();
+            e.Pointer.Capture(null);
+            InvalidateVisual();
+            e.Handled = true;
+        }
+    }
+
+    protected override void OnPointerCaptureLost(PointerCaptureLostEventArgs e)
+    {
+        base.OnPointerCaptureLost(e);
+        if (_isDraggingBoundary)
+        {
+            _isDraggingBoundary = false;
+            _draggingPhoneme = null;
+            DocManager.Inst.EndUndoGroup();
+            InvalidateVisual();
+        }
+    }
+
+    private UPhoneme? FindPhonemeBoundaryAt(double pointerX)
+    {
+        if (Part == null)
+        {
+            return null;
+        }
+
+        double partPos = Part.position;
+        UPhoneme? best = null;
+        double bestDist = BoundaryHitRadius;
+
+        foreach (UPhoneme phoneme in Part.phonemes)
+        {
+            if (phoneme.Parent == null)
+            {
+                continue;
+            }
+
+            double x = (partPos + phoneme.position - TickOffset) * TickWidth;
+            double dist = Math.Abs(pointerX - x);
+            if (dist < bestDist)
+            {
+                bestDist = dist;
+                best = phoneme;
+            }
+        }
+
+        return best;
+    }
+
+    private UPhoneme? FindPhonemeAtTick(double partRelativeTick)
+    {
+        if (Part == null)
+        {
+            return null;
+        }
+
+        foreach (UPhoneme phoneme in Part.phonemes)
+        {
+            if (partRelativeTick >= phoneme.position && partRelativeTick <= phoneme.End)
+            {
+                return phoneme;
+            }
+        }
+        return null;
+    }
+
+    public void OnNext(UCommand cmd, bool isUndo)
+    {
+        switch (cmd)
+        {
+            case NoteCommand:
+            case PartCommand:
+            case PhonemizedNotification:
+            case ExpCommand:
+                InvalidateVisual();
+                break;
+        }
+    }
+}

--- a/OpenUtauMobile/ViewModels/EditorViewModel.cs
+++ b/OpenUtauMobile/ViewModels/EditorViewModel.cs
@@ -48,6 +48,7 @@ public class EditorViewModel : NavigateViewModelBase, ICmdSubscriber, IDisposabl
 {
     // ── 内部状态 ────────────────────────────────────────────────────────
     private readonly Action<UVoicePart, int>? _onRequestEditLyric;
+    private readonly Action<UVoicePart, UNote, int>? _onRequestEditPhoneme;
 
     #region 响应式命令
 
@@ -398,6 +399,10 @@ public class EditorViewModel : NavigateViewModelBase, ICmdSubscriber, IDisposabl
         _onRequestEditLyric = (part, noteIndex) => { _ = ShowLyricEditPopupAsync(part, noteIndex); };
         PianoRollViewModel.RequestEditLyric += _onRequestEditLyric;
 
+        // 订阅音素别名编辑弹窗请求
+        _onRequestEditPhoneme = (part, note, phonemeIndex) => { _ = ShowPhonemeEditPopupAsync(part, note, phonemeIndex); };
+        PianoRollViewModel.RequestEditPhoneme += _onRequestEditPhoneme;
+
         PlaybackTimer = new() // 回放定时器，定时通知回放管理器更新播放位置
         {
             Interval = TimeSpan.FromSeconds(1 / Preferences.Default.PlaybackRefreshRate) // 按用户设置的刷新率计算间隔
@@ -727,6 +732,23 @@ public class EditorViewModel : NavigateViewModelBase, ICmdSubscriber, IDisposabl
         finally
         {
             // 弹窗关闭后释放 ViewModel 资源
+            vm.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// 显示音素别名编辑弹窗。ViewModel 直接执行命令，弹窗关闭不返回任何信息。
+    /// </summary>
+    private static async Task<object?> ShowPhonemeEditPopupAsync(UVoicePart part, UNote note, int phonemeIndex)
+    {
+        PhonemeEditViewModel vm = new PhonemeEditViewModel(part, note, phonemeIndex);
+        try
+        {
+            return await Dispatcher.UIThread.InvokeAsync(() =>
+                PopupService.Show<object>(new PhonemeEditPopup(), vm));
+        }
+        finally
+        {
             vm.Dispose();
         }
     }
@@ -1968,10 +1990,14 @@ public class EditorViewModel : NavigateViewModelBase, ICmdSubscriber, IDisposabl
         _panMotion.Dispose();
         DocManager.Inst.RemoveSubscriber(this); // 取消订阅事件
 
-        // 取消订阅歌词编辑弹窗请求
+        // 取消订阅歌词与音素别名编辑弹窗请求
         if (_onRequestEditLyric != null)
         {
             PianoRollViewModel.RequestEditLyric -= _onRequestEditLyric;
+        }
+        if (_onRequestEditPhoneme != null)
+        {
+            PianoRollViewModel.RequestEditPhoneme -= _onRequestEditPhoneme;
         }
 
         _disposables.Dispose(); // 释放绑定订阅

--- a/OpenUtauMobile/ViewModels/ExpressionOption.cs
+++ b/OpenUtauMobile/ViewModels/ExpressionOption.cs
@@ -1,0 +1,31 @@
+using OpenUtau.Core.Ustx;
+
+namespace OpenUtauMobile.ViewModels;
+
+/// <summary>
+/// 参数选项项（用于绑定到参数选择器列表与菜单）。
+/// </summary>
+public sealed class ExpressionOption
+{
+    /// <summary>
+    /// 参数缩写标识键。
+    /// </summary>
+    public string Key { get; }
+
+    /// <summary>
+    /// 显示名称。
+    /// </summary>
+    public string DisplayName { get; }
+
+    /// <summary>
+    /// 对应的工程参数描述符，无参数项时为 null。
+    /// </summary>
+    public UExpressionDescriptor? Descriptor { get; }
+
+    public ExpressionOption(string key, string displayName, UExpressionDescriptor? descriptor)
+    {
+        Key = key;
+        DisplayName = displayName;
+        Descriptor = descriptor;
+    }
+}

--- a/OpenUtauMobile/ViewModels/PhonemeEditViewModel.cs
+++ b/OpenUtauMobile/ViewModels/PhonemeEditViewModel.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Linq;
+using System.Reactive;
+using OpenUtau.Core;
+using OpenUtau.Core.Ustx;
+using OpenUtauMobile.Helpers;
+using ReactiveUI;
+using ReactiveUI.Fody.Helpers;
+
+namespace OpenUtauMobile.ViewModels;
+
+/// <summary>
+/// 音素别名编辑弹窗 ViewModel。
+/// 支持直接修改音素别名（ChangePhonemeAliasCommand），支持恢复默认别名，支持在声部的音素列表中切换导航。
+/// </summary>
+public class PhonemeEditViewModel : PopupViewModelBase, IDisposable
+{
+    private readonly UVoicePart _part;
+    private int _currentPhonemeIndex;
+
+    /// <summary>
+    /// 当前编辑的音素引用
+    /// </summary>
+    [Reactive]
+    public UPhoneme? CurrentPhoneme { get; private set; }
+
+    /// <summary>
+    /// 当前音素别名（输入框绑定）
+    /// </summary>
+    [Reactive]
+    public string CurrentAlias { get; set; } = "";
+
+    /// <summary>
+    /// 当前音素信息显示
+    /// </summary>
+    [Reactive]
+    public string CurrentPhonemeInfo { get; private set; } = "";
+
+    /// <summary>
+    /// 默认原始音素提示
+    /// </summary>
+    [Reactive]
+    public string RawPhonemeHint { get; private set; } = "";
+
+    /// <summary>
+    /// 取消命令
+    /// </summary>
+    public ReactiveCommand<Unit, Unit> CancelCommand { get; }
+
+    /// <summary>
+    /// 恢复默认别名命令
+    /// </summary>
+    public ReactiveCommand<Unit, Unit> ResetCommand { get; }
+
+    /// <summary>
+    /// "下一个"命令
+    /// </summary>
+    public ReactiveCommand<Unit, Unit> NextCommand { get; }
+
+    /// <summary>
+    /// 确认命令
+    /// </summary>
+    public ReactiveCommand<Unit, Unit> ConfirmCommand { get; }
+
+    /// <summary>
+    /// 焦点请求事件
+    /// </summary>
+    public event Action? FocusRequested;
+
+    public PhonemeEditViewModel(UVoicePart part, UNote note, int phonemeIndex)
+    {
+        _part = part;
+
+        // 查找对应音素在 Part.phonemes 中的序号
+        int index = 0;
+        for (int i = 0; i < _part.phonemes.Count; i++)
+        {
+            if (_part.phonemes[i].Parent == note && _part.phonemes[i].index == phonemeIndex)
+            {
+                index = i;
+                break;
+            }
+        }
+        _currentPhonemeIndex = index;
+
+        CancelCommand = ReactiveCommand.Create(OnCancel);
+        ResetCommand = ReactiveCommand.Create(OnReset);
+        NextCommand = ReactiveCommand.Create(OnNext);
+        ConfirmCommand = ReactiveCommand.Create(OnConfirm);
+
+        LoadCurrentPhoneme();
+    }
+
+    private void LoadCurrentPhoneme()
+    {
+        if (_currentPhonemeIndex >= 0 && _currentPhonemeIndex < _part.phonemes.Count)
+        {
+            CurrentPhoneme = _part.phonemes[_currentPhonemeIndex];
+            string currentVal = CurrentPhoneme.phoneme != CurrentPhoneme.rawPhoneme
+                ? CurrentPhoneme.phoneme
+                : (!string.IsNullOrEmpty(CurrentPhoneme.phoneme) ? CurrentPhoneme.phoneme : "");
+
+            CurrentAlias = currentVal;
+            string lyric = CurrentPhoneme.Parent?.lyric ?? "";
+            string raw = CurrentPhoneme.rawPhoneme;
+            CurrentPhonemeInfo = string.Format(L.S("PhonemeEdit.Info"), lyric, CurrentPhoneme.index + 1);
+            RawPhonemeHint = $"Default: [{raw}]";
+
+            FocusRequested?.Invoke();
+        }
+    }
+
+    private bool HasNext => _currentPhonemeIndex + 1 < _part.phonemes.Count;
+
+    private void SaveCurrentPhonemeEdit()
+    {
+        if (CurrentPhoneme?.Parent == null) return;
+
+        string? newAlias = string.IsNullOrWhiteSpace(CurrentAlias) ? null : CurrentAlias.Trim();
+        UPhonemeOverride o = CurrentPhoneme.Parent.GetPhonemeOverride(CurrentPhoneme.index);
+
+        if (o.phoneme != newAlias)
+        {
+            DocManager.Inst.StartUndoGroup();
+            DocManager.Inst.ExecuteCmd(new ChangePhonemeAliasCommand(_part, CurrentPhoneme.Parent, CurrentPhoneme.index, newAlias));
+            DocManager.Inst.EndUndoGroup();
+        }
+    }
+
+    private void OnCancel()
+    {
+        RaiseClose(null);
+    }
+
+    private void OnReset()
+    {
+        CurrentAlias = "";
+        SaveCurrentPhonemeEdit();
+        RaiseClose(null);
+    }
+
+    private void OnNext()
+    {
+        SaveCurrentPhonemeEdit();
+        if (HasNext)
+        {
+            _currentPhonemeIndex++;
+            LoadCurrentPhoneme();
+        }
+        else
+        {
+            RaiseClose(null);
+        }
+    }
+
+    private void OnConfirm()
+    {
+        SaveCurrentPhonemeEdit();
+        RaiseClose(null);
+    }
+
+    public void Dispose()
+    {
+        CancelCommand.Dispose();
+        ResetCommand.Dispose();
+        NextCommand.Dispose();
+        ConfirmCommand.Dispose();
+    }
+}

--- a/OpenUtauMobile/ViewModels/PianoRollViewModel.cs
+++ b/OpenUtauMobile/ViewModels/PianoRollViewModel.cs
@@ -641,7 +641,7 @@ public class PianoRollViewModel : ViewModelBase, IDisposable, ICmdSubscriber
         });
 
         // 加载音素面板偏好
-        PhonemePanelHeight = Math.Clamp(OpenUtau.Core.Util.Preferences.Default.PhonemePanelHeight, 36.0, 400.0);
+        PhonemePanelHeight = Math.Max(0.0, OpenUtau.Core.Util.Preferences.Default.PhonemePanelHeight);
         PhonemePanelMode = (PhonemePanelMode)Math.Clamp(OpenUtau.Core.Util.Preferences.Default.PhonemePanelMode, 0, 3);
         PrimaryExpressionKey = string.IsNullOrEmpty(OpenUtau.Core.Util.Preferences.Default.PrimaryExpressionKey)
             ? "vel"

--- a/OpenUtauMobile/ViewModels/PianoRollViewModel.cs
+++ b/OpenUtauMobile/ViewModels/PianoRollViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -28,6 +28,17 @@ using Point = Avalonia.Point;
 using Size = Avalonia.Size;
 
 namespace OpenUtauMobile.ViewModels;
+
+/// <summary>
+/// 音素与参数面板编辑模式
+/// </summary>
+public enum PhonemePanelMode
+{
+    PhonemeSimple, // 简易音素 (SynthV 风格块状)
+    PhonemeAdvanced, // 高级音素 (OpenUtau 风格包络与控制点)
+    ParameterDraw, // 参数绘制
+    ParameterErase // 参数擦除
+}
 
 /// <summary>
 /// 钢琴卷帘编辑模式
@@ -234,6 +245,53 @@ public class PianoRollViewModel : ViewModelBase, IDisposable, ICmdSubscriber
     /// </summary>
     [Reactive]
     public bool IsSelecting { get; private set; }
+
+    // ── 音素与参数面板属性 ────────────────────────────
+    [Reactive] public PhonemePanelMode PhonemePanelMode { get; set; } = PhonemePanelMode.PhonemeSimple;
+    [Reactive] public double PhonemePanelHeight { get; set; } = 128;
+    [Reactive] public string PrimaryExpressionKey { get; set; } = "vel";
+    [Reactive] public string SecondaryExpressionKey { get; set; } = string.Empty;
+
+    public bool IsPhonemeSimpleMode => PhonemePanelMode == PhonemePanelMode.PhonemeSimple;
+    public bool IsPhonemeAdvancedMode => PhonemePanelMode == PhonemePanelMode.PhonemeAdvanced;
+    public bool IsParameterDrawMode => PhonemePanelMode == PhonemePanelMode.ParameterDraw;
+    public bool IsParameterEraseMode => PhonemePanelMode == PhonemePanelMode.ParameterErase;
+    public bool IsParameterMode => PhonemePanelMode == PhonemePanelMode.ParameterDraw || PhonemePanelMode == PhonemePanelMode.ParameterErase;
+    public bool IsPhonemePanelVisible => IsVoiceMode && PhonemePanelHeight > 0;
+
+    public ObservableCollectionExtended<UExpressionDescriptor> AvailableExpressions { get; init; } = [];
+    public ObservableCollectionExtended<UExpressionDescriptor?> AvailableSecondaryExpressions { get; init; } = [];
+
+    public UExpressionDescriptor? PrimaryExpressionDescriptor
+    {
+        get => AvailableExpressions.FirstOrDefault(x => x.abbr == PrimaryExpressionKey);
+        set
+        {
+            if (value != null && value.abbr != PrimaryExpressionKey)
+            {
+                PrimaryExpressionKey = value.abbr;
+                this.RaisePropertyChanged(nameof(PrimaryExpressionDescriptor));
+            }
+        }
+    }
+
+    public UExpressionDescriptor? SecondaryExpressionDescriptor
+    {
+        get => AvailableSecondaryExpressions.FirstOrDefault(x => (x?.abbr ?? string.Empty) == SecondaryExpressionKey);
+        set
+        {
+            string newKey = value?.abbr ?? string.Empty;
+            if (newKey != SecondaryExpressionKey)
+            {
+                SecondaryExpressionKey = newKey;
+                this.RaisePropertyChanged(nameof(SecondaryExpressionDescriptor));
+            }
+        }
+    }
+
+    public System.Windows.Input.ICommand SwapExpressionsCommand { get; }
+    public System.Windows.Input.ICommand SelectPrimaryExpressionCommand { get; }
+    public System.Windows.Input.ICommand SelectSecondaryExpressionCommand { get; }
 
     #endregion
 
@@ -477,6 +535,82 @@ public class PianoRollViewModel : ViewModelBase, IDisposable, ICmdSubscriber
     /// </summary>
     public event Action<UVoicePart, int>? RequestEditLyric;
 
+    public void RaiseRequestEditLyric(UVoicePart part, int noteIndex)
+    {
+        RequestEditLyric?.Invoke(part, noteIndex);
+    }
+
+    /// <summary>
+    /// 请求打开音素别名编辑弹窗。
+    /// 参数：(EditingVoicePart, 所属音符 UNote, 音素索引 index)
+    /// </summary>
+    public event Action<UVoicePart, UNote, int>? RequestEditPhoneme;
+
+    public void RaiseRequestEditPhoneme(UVoicePart part, UNote note, int phonemeIndex)
+    {
+        RequestEditPhoneme?.Invoke(part, note, phonemeIndex);
+    }
+
+    public void SwapExpressions()
+    {
+        if (string.IsNullOrEmpty(SecondaryExpressionKey) || SecondaryExpressionKey == PrimaryExpressionKey)
+        {
+            return;
+        }
+
+        string temp = PrimaryExpressionKey;
+        PrimaryExpressionKey = SecondaryExpressionKey;
+        SecondaryExpressionKey = temp;
+        this.RaisePropertyChanged(nameof(PrimaryExpressionDescriptor));
+        this.RaisePropertyChanged(nameof(SecondaryExpressionDescriptor));
+    }
+
+    public void RefreshAvailableExpressions()
+    {
+        AvailableExpressions.Clear();
+        AvailableSecondaryExpressions.Clear();
+
+        UProject? project = DocManager.Inst.Project;
+        if (project == null)
+        {
+            return;
+        }
+
+        List<UExpressionDescriptor> list = new();
+        UTrack? track = null;
+        if (EditingVoicePart != null && EditingVoicePart.trackNo >= 0 && EditingVoicePart.trackNo < project.tracks.Count)
+        {
+            track = project.tracks[EditingVoicePart.trackNo];
+        }
+
+        if (track != null)
+        {
+            list = track.GetSupportedExps(project);
+        }
+
+        if (list.Count == 0)
+        {
+            foreach (KeyValuePair<string, UExpressionDescriptor> pair in project.expressions)
+            {
+                list.Add(pair.Value);
+            }
+        }
+
+        AvailableExpressions.AddRange(list);
+
+        UExpressionDescriptor noneDescriptor = new UExpressionDescriptor(L.S("PhonemePanel.Param.None"), string.Empty, 0, 0, 0);
+        AvailableSecondaryExpressions.Add(noneDescriptor);
+        AvailableSecondaryExpressions.AddRange(list);
+
+        if (!AvailableExpressions.Any(x => x.abbr == PrimaryExpressionKey))
+        {
+            PrimaryExpressionKey = AvailableExpressions.FirstOrDefault()?.abbr ?? "vel";
+        }
+
+        this.RaisePropertyChanged(nameof(PrimaryExpressionDescriptor));
+        this.RaisePropertyChanged(nameof(SecondaryExpressionDescriptor));
+    }
+
     // 拆分放大镜事件
     public event Action<Point>? RequestMagnifierOpen;
     public event Action<Point>? RequestMagnifierUpdate;
@@ -488,6 +622,31 @@ public class PianoRollViewModel : ViewModelBase, IDisposable, ICmdSubscriber
     {
         _toneTimer = new DispatcherTimer();
         _toneTimer.Tick += (_, _) => { StopPreviewTone(); };
+
+        IObservable<bool> canSwap = this.WhenAnyValue(x => x.SecondaryExpressionKey, key => !string.IsNullOrEmpty(key));
+        SwapExpressionsCommand = ReactiveCommand.Create(SwapExpressions, canSwap);
+        SelectPrimaryExpressionCommand = ReactiveCommand.Create<UExpressionDescriptor>(desc =>
+        {
+            if (desc != null)
+            {
+                PrimaryExpressionDescriptor = desc;
+            }
+        });
+        SelectSecondaryExpressionCommand = ReactiveCommand.Create<UExpressionDescriptor>(desc =>
+        {
+            if (desc != null)
+            {
+                SecondaryExpressionDescriptor = desc;
+            }
+        });
+
+        // 加载音素面板偏好
+        PhonemePanelHeight = Math.Clamp(OpenUtau.Core.Util.Preferences.Default.PhonemePanelHeight, 36.0, 400.0);
+        PhonemePanelMode = (PhonemePanelMode)Math.Clamp(OpenUtau.Core.Util.Preferences.Default.PhonemePanelMode, 0, 3);
+        PrimaryExpressionKey = string.IsNullOrEmpty(OpenUtau.Core.Util.Preferences.Default.PrimaryExpressionKey)
+            ? "vel"
+            : OpenUtau.Core.Util.Preferences.Default.PrimaryExpressionKey;
+        SecondaryExpressionKey = OpenUtau.Core.Util.Preferences.Default.SecondaryExpressionKey ?? string.Empty;
 
         DocManager.Inst.AddSubscriber(this);
 
@@ -525,9 +684,63 @@ public class PianoRollViewModel : ViewModelBase, IDisposable, ICmdSubscriber
             .Subscribe(_ =>
             {
                 this.RaisePropertyChanged(nameof(IsVoiceMode));
+                this.RaisePropertyChanged(nameof(IsPhonemePanelVisible));
+                RefreshAvailableExpressions();
                 InvalidateMaxOffsets();
                 ApplyViewportLimits();
                 var __ = UpdatePortraitAsync(); // 更新立绘
+            })
+            .DisposeWith(_disposables);
+
+        // 音素面板高度变化监听
+        this.WhenAnyValue(x => x.PhonemePanelHeight)
+            .Subscribe(height =>
+            {
+                OpenUtau.Core.Util.Preferences.Default.PhonemePanelHeight = height;
+                OpenUtau.Core.Util.Preferences.Save();
+                this.RaisePropertyChanged(nameof(IsPhonemePanelVisible));
+            })
+            .DisposeWith(_disposables);
+
+        // 音素面板模式切换监听
+        this.WhenAnyValue(x => x.PhonemePanelMode)
+            .Subscribe(mode =>
+            {
+                OpenUtau.Core.Util.Preferences.Default.PhonemePanelMode = (int)mode;
+                OpenUtau.Core.Util.Preferences.Save();
+                this.RaisePropertyChanged(nameof(IsPhonemeSimpleMode));
+                this.RaisePropertyChanged(nameof(IsPhonemeAdvancedMode));
+                this.RaisePropertyChanged(nameof(IsParameterDrawMode));
+                this.RaisePropertyChanged(nameof(IsParameterEraseMode));
+                this.RaisePropertyChanged(nameof(IsParameterMode));
+
+                switch (mode)
+                {
+                    case PhonemePanelMode.PhonemeSimple:
+                        ToastService.Enqueue(L.S("PhonemePanel.Toast.Simple"));
+                        break;
+                    case PhonemePanelMode.PhonemeAdvanced:
+                        ToastService.Enqueue(L.S("PhonemePanel.Toast.Advanced"));
+                        break;
+                    case PhonemePanelMode.ParameterDraw:
+                        ToastService.Enqueue(L.S("PhonemePanel.Toast.Draw"));
+                        break;
+                    case PhonemePanelMode.ParameterErase:
+                        ToastService.Enqueue(L.S("PhonemePanel.Toast.Erase"));
+                        break;
+                }
+            })
+            .DisposeWith(_disposables);
+
+        // 参数选择变更监听
+        this.WhenAnyValue(x => x.PrimaryExpressionKey, x => x.SecondaryExpressionKey)
+            .Subscribe(t =>
+            {
+                OpenUtau.Core.Util.Preferences.Default.PrimaryExpressionKey = t.Item1;
+                OpenUtau.Core.Util.Preferences.Default.SecondaryExpressionKey = t.Item2;
+                OpenUtau.Core.Util.Preferences.Save();
+                this.RaisePropertyChanged(nameof(PrimaryExpressionDescriptor));
+                this.RaisePropertyChanged(nameof(SecondaryExpressionDescriptor));
             })
             .DisposeWith(_disposables);
 

--- a/OpenUtauMobile/ViewModels/PianoRollViewModel.cs
+++ b/OpenUtauMobile/ViewModels/PianoRollViewModel.cs
@@ -259,35 +259,44 @@ public class PianoRollViewModel : ViewModelBase, IDisposable, ICmdSubscriber
     public bool IsParameterMode => PhonemePanelMode == PhonemePanelMode.ParameterDraw || PhonemePanelMode == PhonemePanelMode.ParameterErase;
     public bool IsPhonemePanelVisible => IsVoiceMode && PhonemePanelHeight > 0;
 
-    public ObservableCollectionExtended<UExpressionDescriptor> AvailableExpressions { get; init; } = [];
-    public ObservableCollectionExtended<UExpressionDescriptor?> AvailableSecondaryExpressions { get; init; } = [];
+    public ObservableCollectionExtended<ExpressionOption> AvailableExpressions { get; init; } = [];
+    public ObservableCollectionExtended<ExpressionOption> AvailableSecondaryExpressions { get; init; } = [];
 
-    public UExpressionDescriptor? PrimaryExpressionDescriptor
+    public string PrimaryExpressionDisplayName
     {
-        get => AvailableExpressions.FirstOrDefault(x => x.abbr == PrimaryExpressionKey);
-        set
+        get
         {
-            if (value != null && value.abbr != PrimaryExpressionKey)
+            ExpressionOption? opt = AvailableExpressions.FirstOrDefault(x => x.Key == PrimaryExpressionKey);
+            if (opt != null)
             {
-                PrimaryExpressionKey = value.abbr;
-                this.RaisePropertyChanged(nameof(PrimaryExpressionDescriptor));
+                return opt.DisplayName;
             }
+            return string.IsNullOrEmpty(PrimaryExpressionKey) ? string.Empty : PrimaryExpressionKey.ToUpperInvariant();
         }
     }
 
-    public UExpressionDescriptor? SecondaryExpressionDescriptor
+    public string SecondaryExpressionDisplayName
     {
-        get => AvailableSecondaryExpressions.FirstOrDefault(x => (x?.abbr ?? string.Empty) == SecondaryExpressionKey);
-        set
+        get
         {
-            string newKey = value?.abbr ?? string.Empty;
-            if (newKey != SecondaryExpressionKey)
+            if (string.IsNullOrEmpty(SecondaryExpressionKey))
             {
-                SecondaryExpressionKey = newKey;
-                this.RaisePropertyChanged(nameof(SecondaryExpressionDescriptor));
+                return L.S("PhonemePanel.Param.None");
             }
+            ExpressionOption? opt = AvailableSecondaryExpressions.FirstOrDefault(x => x.Key == SecondaryExpressionKey);
+            if (opt != null)
+            {
+                return opt.DisplayName;
+            }
+            return SecondaryExpressionKey.ToUpperInvariant();
         }
     }
+
+    public UExpressionDescriptor? PrimaryExpressionDescriptor =>
+        AvailableExpressions.FirstOrDefault(x => x.Key == PrimaryExpressionKey)?.Descriptor;
+
+    public UExpressionDescriptor? SecondaryExpressionDescriptor =>
+        AvailableSecondaryExpressions.FirstOrDefault(x => x.Key == SecondaryExpressionKey)?.Descriptor;
 
     public System.Windows.Input.ICommand SwapExpressionsCommand { get; }
     public System.Windows.Input.ICommand SelectPrimaryExpressionCommand { get; }
@@ -596,17 +605,26 @@ public class PianoRollViewModel : ViewModelBase, IDisposable, ICmdSubscriber
             }
         }
 
-        AvailableExpressions.AddRange(list);
-
-        UExpressionDescriptor noneDescriptor = new UExpressionDescriptor(L.S("PhonemePanel.Param.None"), string.Empty, 0, 0, 0);
-        AvailableSecondaryExpressions.Add(noneDescriptor);
-        AvailableSecondaryExpressions.AddRange(list);
-
-        if (!AvailableExpressions.Any(x => x.abbr == PrimaryExpressionKey))
+        foreach (UExpressionDescriptor desc in list)
         {
-            PrimaryExpressionKey = AvailableExpressions.FirstOrDefault()?.abbr ?? "vel";
+            string disp = string.IsNullOrWhiteSpace(desc.abbr) ? (desc.name ?? string.Empty) : desc.abbr.ToUpperInvariant();
+            AvailableExpressions.Add(new ExpressionOption(desc.abbr, disp, desc));
         }
 
+        AvailableSecondaryExpressions.Add(new ExpressionOption(string.Empty, L.S("PhonemePanel.Param.None"), null));
+        foreach (UExpressionDescriptor desc in list)
+        {
+            string disp = string.IsNullOrWhiteSpace(desc.abbr) ? (desc.name ?? string.Empty) : desc.abbr.ToUpperInvariant();
+            AvailableSecondaryExpressions.Add(new ExpressionOption(desc.abbr, disp, desc));
+        }
+
+        if (!AvailableExpressions.Any(x => x.Key == PrimaryExpressionKey))
+        {
+            PrimaryExpressionKey = AvailableExpressions.FirstOrDefault()?.Key ?? "vel";
+        }
+
+        this.RaisePropertyChanged(nameof(PrimaryExpressionDisplayName));
+        this.RaisePropertyChanged(nameof(SecondaryExpressionDisplayName));
         this.RaisePropertyChanged(nameof(PrimaryExpressionDescriptor));
         this.RaisePropertyChanged(nameof(SecondaryExpressionDescriptor));
     }
@@ -625,18 +643,18 @@ public class PianoRollViewModel : ViewModelBase, IDisposable, ICmdSubscriber
 
         IObservable<bool> canSwap = this.WhenAnyValue(x => x.SecondaryExpressionKey, key => !string.IsNullOrEmpty(key));
         SwapExpressionsCommand = ReactiveCommand.Create(SwapExpressions, canSwap);
-        SelectPrimaryExpressionCommand = ReactiveCommand.Create<UExpressionDescriptor>(desc =>
+        SelectPrimaryExpressionCommand = ReactiveCommand.Create<ExpressionOption>(opt =>
         {
-            if (desc != null)
+            if (opt != null && !string.IsNullOrEmpty(opt.Key))
             {
-                PrimaryExpressionDescriptor = desc;
+                PrimaryExpressionKey = opt.Key;
             }
         });
-        SelectSecondaryExpressionCommand = ReactiveCommand.Create<UExpressionDescriptor>(desc =>
+        SelectSecondaryExpressionCommand = ReactiveCommand.Create<ExpressionOption>(opt =>
         {
-            if (desc != null)
+            if (opt != null)
             {
-                SecondaryExpressionDescriptor = desc;
+                SecondaryExpressionKey = opt.Key;
             }
         });
 
@@ -739,6 +757,8 @@ public class PianoRollViewModel : ViewModelBase, IDisposable, ICmdSubscriber
                 OpenUtau.Core.Util.Preferences.Default.PrimaryExpressionKey = t.Item1;
                 OpenUtau.Core.Util.Preferences.Default.SecondaryExpressionKey = t.Item2;
                 OpenUtau.Core.Util.Preferences.Save();
+                this.RaisePropertyChanged(nameof(PrimaryExpressionDisplayName));
+                this.RaisePropertyChanged(nameof(SecondaryExpressionDisplayName));
                 this.RaisePropertyChanged(nameof(PrimaryExpressionDescriptor));
                 this.RaisePropertyChanged(nameof(SecondaryExpressionDescriptor));
             })

--- a/OpenUtauMobile/ViewModels/PianoRollViewModel.cs
+++ b/OpenUtauMobile/ViewModels/PianoRollViewModel.cs
@@ -658,14 +658,6 @@ public class PianoRollViewModel : ViewModelBase, IDisposable, ICmdSubscriber
             }
         });
 
-        // 加载音素面板偏好
-        PhonemePanelHeight = Math.Max(0.0, OpenUtau.Core.Util.Preferences.Default.PhonemePanelHeight);
-        PhonemePanelMode = (PhonemePanelMode)Math.Clamp(OpenUtau.Core.Util.Preferences.Default.PhonemePanelMode, 0, 3);
-        PrimaryExpressionKey = string.IsNullOrEmpty(OpenUtau.Core.Util.Preferences.Default.PrimaryExpressionKey)
-            ? "vel"
-            : OpenUtau.Core.Util.Preferences.Default.PrimaryExpressionKey;
-        SecondaryExpressionKey = OpenUtau.Core.Util.Preferences.Default.SecondaryExpressionKey ?? string.Empty;
-
         DocManager.Inst.AddSubscriber(this);
 
         PlayPosTick = DocManager.Inst.playPosTick;
@@ -712,10 +704,8 @@ public class PianoRollViewModel : ViewModelBase, IDisposable, ICmdSubscriber
 
         // 音素面板高度变化监听
         this.WhenAnyValue(x => x.PhonemePanelHeight)
-            .Subscribe(height =>
+            .Subscribe(_ =>
             {
-                OpenUtau.Core.Util.Preferences.Default.PhonemePanelHeight = height;
-                OpenUtau.Core.Util.Preferences.Save();
                 this.RaisePropertyChanged(nameof(IsPhonemePanelVisible));
             })
             .DisposeWith(_disposables);
@@ -724,8 +714,6 @@ public class PianoRollViewModel : ViewModelBase, IDisposable, ICmdSubscriber
         this.WhenAnyValue(x => x.PhonemePanelMode)
             .Subscribe(mode =>
             {
-                OpenUtau.Core.Util.Preferences.Default.PhonemePanelMode = (int)mode;
-                OpenUtau.Core.Util.Preferences.Save();
                 this.RaisePropertyChanged(nameof(IsPhonemeSimpleMode));
                 this.RaisePropertyChanged(nameof(IsPhonemeAdvancedMode));
                 this.RaisePropertyChanged(nameof(IsParameterDrawMode));
@@ -752,11 +740,8 @@ public class PianoRollViewModel : ViewModelBase, IDisposable, ICmdSubscriber
 
         // 参数选择变更监听
         this.WhenAnyValue(x => x.PrimaryExpressionKey, x => x.SecondaryExpressionKey)
-            .Subscribe(t =>
+            .Subscribe(_ =>
             {
-                OpenUtau.Core.Util.Preferences.Default.PrimaryExpressionKey = t.Item1;
-                OpenUtau.Core.Util.Preferences.Default.SecondaryExpressionKey = t.Item2;
-                OpenUtau.Core.Util.Preferences.Save();
                 this.RaisePropertyChanged(nameof(PrimaryExpressionDisplayName));
                 this.RaisePropertyChanged(nameof(SecondaryExpressionDisplayName));
                 this.RaisePropertyChanged(nameof(PrimaryExpressionDescriptor));

--- a/OpenUtauMobile/Views/EditorView.axaml
+++ b/OpenUtauMobile/Views/EditorView.axaml
@@ -22,7 +22,7 @@
     </UserControl.Resources>
 
     <UserControl.Styles>
-        <Style Selector="Grid#SplitDragHandle">
+        <Style Selector="Grid#SplitDragHandle, Grid#PhonemeSplitHandle">
             <Setter Property="Opacity" Value="0.92" />
             <Setter Property="Cursor" Value="{x:Static local:ViewConstants.cursorSizeNS}" />
             <Setter Property="Transitions">
@@ -32,10 +32,10 @@
                 </Transitions>
             </Setter>
         </Style>
-        <Style Selector="Grid#SplitDragHandle:pointerover">
+        <Style Selector="Grid#SplitDragHandle:pointerover, Grid#PhonemeSplitHandle:pointerover">
             <Setter Property="Opacity" Value="1" />
         </Style>
-        <Style Selector="Grid#SplitDragHandle:pressed">
+        <Style Selector="Grid#SplitDragHandle:pressed, Grid#PhonemeSplitHandle:pressed">
             <Setter Property="Opacity" Value="1" />
         </Style>
     </UserControl.Styles>
@@ -326,7 +326,7 @@
                   Grid.Row="1"
                   Grid.Column="0"
                   Grid.ColumnSpan="2"
-                Background="{DynamicResource surface-editor-canvas-bg}">
+                Background="{DynamicResource Sem.Color.SurfaceContainerLow}">
 
                 <!-- 上下文为PianoRollViewModel，放大镜的Source -->
                 <Grid Grid.Row="0" ClipToBounds="True"
@@ -341,11 +341,13 @@
                         <RowDefinition
                             Height="{Binding Source={x:Static local:ViewConstants.PianoRollTickRulerHeight}, Converter={StaticResource DoubleToGridLengthConverter}}" />
                         <RowDefinition Height="*" />
+                        <RowDefinition Height="0" />
+                        <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
                     <!-- 左上角占位（标尺行 × 琴键列交叉区） -->
                     <Border Grid.Row="0"
                             Grid.Column="0"
-                            Background="{DynamicResource surface-editor-canvas-bg}" />
+                            Background="{DynamicResource Sem.Color.SurfaceContainerLow}" />
                     <!-- 钢琴键画布（Row 1, Col 0） -->
                     <Border Grid.Row="1" Grid.Column="0" IsVisible="{Binding IsVoiceMode}">
                         <c:PianoKeysCanvas ClipToBounds="True"
@@ -457,8 +459,71 @@
                                    MaxWidth="80" TextTrimming="CharacterEllipsis"
                                    ToolTip.Tip="{Binding EditingWavePart.DisplayName}" />
                     </StackPanel>
+
+                    <!-- 钢琴卷帘与音素/参数面板分隔条（Row 2） -->
+                    <Grid Grid.Row="2"
+                          Grid.Column="0"
+                          Grid.ColumnSpan="2"
+                          Height="24"
+                          Margin="0,-12,0,-12"
+                          Background="Transparent"
+                          ClipToBounds="False"
+                          ZIndex="50"
+                          Cursor="{x:Static local:ViewConstants.cursorSizeNS}"
+                          IsVisible="{Binding IsPhonemePanelVisible}"
+                          x:Name="PhonemeSplitHandle"
+                          ToolTip.Tip="{DynamicResource PhonemePanel.Split.Tooltip}">
+                        <!-- 背景横向细分割线 -->
+                        <Border Height="1"
+                                VerticalAlignment="Center"
+                                HorizontalAlignment="Stretch"
+                                Background="{DynamicResource Sem.Color.OutlineVariant}"
+                                IsHitTestVisible="False" />
+                        <!-- 中间胶囊手柄（悬浮居中跨越分割线，与主分割条完全一致） -->
+                        <Grid x:Name="PhonemeSplitHandlePill"
+                              Width="{x:Static local:ViewConstants.EditorSplitHandleWidth}"
+                              Height="{x:Static local:ViewConstants.EditorSplitHandleHeight}"
+                              HorizontalAlignment="Center"
+                              VerticalAlignment="Center"
+                              IsHitTestVisible="False">
+                            <Path Data="M 0,12 
+                                       C 0,12 3,12 6,6 
+                                       C 9,0 12,0 12,0 
+                                       H 36 
+                                       C 36,0 39,0 42,6 
+                                       C 45,12 48,12 48,12 
+                                       C 48,12 45,12 42,18 
+                                       C 39,24 36,24 36,24 
+                                       H 12 
+                                       C 12,24 9,24 6,18 
+                                       C 3,12 0,12 0,12 
+                                       Z"
+                                  Fill="{DynamicResource Sem.Color.Surface}"
+                                  Stroke="{DynamicResource Sem.Color.Outline}"
+                                  StrokeThickness="1"
+                                  Stretch="Fill" />
+                            <StackPanel Orientation="Vertical"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center"
+                                        Spacing="3"
+                                        IsHitTestVisible="False">
+                                <Rectangle Width="12" Height="2" RadiusX="1" RadiusY="1"
+                                           Fill="{DynamicResource Sem.Color.OnSurfaceVariant}" Opacity="0.58" />
+                                <Rectangle Width="12" Height="2" RadiusX="1" RadiusY="1"
+                                           Fill="{DynamicResource Sem.Color.OnSurfaceVariant}" Opacity="0.58" />
+                            </StackPanel>
+                        </Grid>
+                    </Grid>
+
+                    <!-- 音素与参数编辑面板（Row 3） -->
+                    <c:PhonemeParamPanel Grid.Row="3"
+                                         Grid.Column="0"
+                                         Grid.ColumnSpan="2"
+                                         Height="{Binding PhonemePanelHeight}"
+                                         IsVisible="{Binding IsPhonemePanelVisible}" />
+
                     <!-- 没有活动分片时的遮罩 -->
-                    <Border Grid.Row="0" Grid.RowSpan="2" Grid.Column="0" Grid.ColumnSpan="2"
+                    <Border Grid.Row="0" Grid.RowSpan="4" Grid.Column="0" Grid.ColumnSpan="2"
                             Background="{DynamicResource Sem.Color.SurfaceVariant}"
                             ZIndex="150"
                             IsHitTestVisible="True">

--- a/OpenUtauMobile/Views/EditorView.axaml
+++ b/OpenUtauMobile/Views/EditorView.axaml
@@ -470,7 +470,7 @@
                           ClipToBounds="False"
                           ZIndex="50"
                           Cursor="{x:Static local:ViewConstants.cursorSizeNS}"
-                          IsVisible="{Binding IsPhonemePanelVisible}"
+                          IsVisible="{Binding IsVoiceMode}"
                           x:Name="PhonemeSplitHandle"
                           ToolTip.Tip="{DynamicResource PhonemePanel.Split.Tooltip}">
                         <!-- 背景横向细分割线 -->

--- a/OpenUtauMobile/Views/EditorView.axaml.cs
+++ b/OpenUtauMobile/Views/EditorView.axaml.cs
@@ -534,11 +534,6 @@ public partial class EditorView : UserControl
     private double _phonemeSplitPressHeight;
     private double _phonemeHandleXOffset;
     private double _phonemeSplitPressXOffset;
-    private double _lastUncollapsedPhonemeHeight = 128.0;
-    private DateTime _lastPhonemeSplitClickTime = DateTime.MinValue;
-    private Point _lastPhonemeSplitClickPoint;
-    private const double PhonemeSplitDoubleClickMaxTimeMs = 350;
-    private const double PhonemeSplitDoubleClickMaxDistance = 24.0;
 
     private void OnPhonemeSplitHandlePointerPressed(object? sender, PointerPressedEventArgs e)
     {
@@ -549,37 +544,10 @@ public partial class EditorView : UserControl
 
         Point pos = e.GetPosition(this);
 
-        // 双击手柄快速折叠 / 展开
-        DateTime now = DateTime.UtcNow;
-        double elapsedMs = (now - _lastPhonemeSplitClickTime).TotalMilliseconds;
-        double dist = Math.Abs(pos.X - _lastPhonemeSplitClickPoint.X) + Math.Abs(pos.Y - _lastPhonemeSplitClickPoint.Y);
-        if (elapsedMs < PhonemeSplitDoubleClickMaxTimeMs && dist < PhonemeSplitDoubleClickMaxDistance)
-        {
-            if (vm.PianoRollViewModel.PhonemePanelHeight > 0)
-            {
-                _lastUncollapsedPhonemeHeight = vm.PianoRollViewModel.PhonemePanelHeight;
-                vm.PianoRollViewModel.PhonemePanelHeight = 0;
-            }
-            else
-            {
-                vm.PianoRollViewModel.PhonemePanelHeight = _lastUncollapsedPhonemeHeight > 30 ? _lastUncollapsedPhonemeHeight : 128.0;
-            }
-            _lastPhonemeSplitClickTime = DateTime.MinValue;
-            e.Handled = true;
-            return;
-        }
-
-        _lastPhonemeSplitClickTime = now;
-        _lastPhonemeSplitClickPoint = pos;
-
         _phonemeSplitDragging = true;
         _phonemeSplitPressX = pos.X;
         _phonemeSplitPressY = pos.Y;
         _phonemeSplitPressHeight = vm.PianoRollViewModel.PhonemePanelHeight;
-        if (_phonemeSplitPressHeight > 30)
-        {
-            _lastUncollapsedPhonemeHeight = _phonemeSplitPressHeight;
-        }
         _phonemeSplitPressXOffset = _phonemeHandleXOffset;
         e.Pointer.Capture(PhonemeSplitHandle);
         e.Handled = true;
@@ -610,16 +578,6 @@ public partial class EditorView : UserControl
         }
 
         double newHeight = Math.Clamp(_phonemeSplitPressHeight + deltaY, 0.0, maxPanelHeight);
-        if (newHeight < 16.0 && deltaY < 0)
-        {
-            newHeight = 0.0;
-        }
-
-        if (newHeight > 30)
-        {
-            _lastUncollapsedPhonemeHeight = newHeight;
-        }
-
         vm.PianoRollViewModel.PhonemePanelHeight = newHeight;
 
         // 水平滑动药丸手柄位置

--- a/OpenUtauMobile/Views/EditorView.axaml.cs
+++ b/OpenUtauMobile/Views/EditorView.axaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using Avalonia;
@@ -41,6 +41,11 @@ public partial class EditorView : UserControl
         SplitDragHandle.PointerMoved += OnSplitHandlePointerMoved;
         SplitDragHandle.PointerReleased += OnSplitHandlePointerReleased;
         SplitDragHandle.PointerCaptureLost += OnSplitHandlePointerCaptureLost;
+
+        PhonemeSplitHandle.PointerPressed += OnPhonemeSplitHandlePointerPressed;
+        PhonemeSplitHandle.PointerMoved += OnPhonemeSplitHandlePointerMoved;
+        PhonemeSplitHandle.PointerReleased += OnPhonemeSplitHandlePointerReleased;
+        PhonemeSplitHandle.PointerCaptureLost += OnPhonemeSplitHandlePointerCaptureLost;
         AttachedToVisualTree += (_, _) => InitializeResponsiveLayout();
 
         // 初始化轨道头列宽动画
@@ -517,6 +522,77 @@ public partial class EditorView : UserControl
     private void OnSplitHandlePointerCaptureLost(object? sender, PointerCaptureLostEventArgs e)
     {
         ResetSplitDragState();
+    }
+
+    #endregion
+
+    #region 音素与参数面板分割手势
+
+    private bool _phonemeSplitDragging;
+    private double _phonemeSplitPressX;
+    private double _phonemeSplitPressY;
+    private double _phonemeSplitPressHeight;
+    private double _phonemeHandleXOffset;
+    private double _phonemeSplitPressXOffset;
+
+    private void OnPhonemeSplitHandlePointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (DataContext is not EditorViewModel vm || !e.GetCurrentPoint(PhonemeSplitHandle).Properties.IsLeftButtonPressed)
+        {
+            return;
+        }
+
+        _phonemeSplitDragging = true;
+        Point pos = e.GetPosition(this);
+        _phonemeSplitPressX = pos.X;
+        _phonemeSplitPressY = pos.Y;
+        _phonemeSplitPressHeight = vm.PianoRollViewModel.PhonemePanelHeight;
+        _phonemeSplitPressXOffset = _phonemeHandleXOffset;
+        e.Pointer.Capture(PhonemeSplitHandle);
+        e.Handled = true;
+    }
+
+    private void OnPhonemeSplitHandlePointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (!_phonemeSplitDragging || DataContext is not EditorViewModel vm)
+        {
+            return;
+        }
+
+        if (!e.GetCurrentPoint(null).Properties.IsLeftButtonPressed)
+        {
+            e.Pointer.Capture(null);
+            _phonemeSplitDragging = false;
+            return;
+        }
+
+        Point currentPoint = e.GetPosition(this);
+        double deltaY = _phonemeSplitPressY - currentPoint.Y;
+        double newHeight = Math.Clamp(_phonemeSplitPressHeight + deltaY, 36.0, 400.0);
+        vm.PianoRollViewModel.PhonemePanelHeight = newHeight;
+
+        // 水平滑动药丸手柄位置
+        double deltaX = currentPoint.X - _phonemeSplitPressX;
+        double maxOffset = Math.Max(10.0, (Bounds.Width - ViewConstants.EditorSplitHandleWidth) * 0.5 - 50.0);
+        _phonemeHandleXOffset = Math.Clamp(_phonemeSplitPressXOffset + deltaX, -maxOffset, maxOffset);
+        PhonemeSplitHandlePill.RenderTransform = new TranslateTransform(_phonemeHandleXOffset, 0);
+
+        e.Handled = true;
+    }
+
+    private void OnPhonemeSplitHandlePointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        if (_phonemeSplitDragging)
+        {
+            _phonemeSplitDragging = false;
+            e.Pointer.Capture(null);
+            e.Handled = true;
+        }
+    }
+
+    private void OnPhonemeSplitHandlePointerCaptureLost(object? sender, PointerCaptureLostEventArgs e)
+    {
+        _phonemeSplitDragging = false;
     }
 
     #endregion

--- a/OpenUtauMobile/Views/EditorView.axaml.cs
+++ b/OpenUtauMobile/Views/EditorView.axaml.cs
@@ -534,6 +534,11 @@ public partial class EditorView : UserControl
     private double _phonemeSplitPressHeight;
     private double _phonemeHandleXOffset;
     private double _phonemeSplitPressXOffset;
+    private double _lastUncollapsedPhonemeHeight = 128.0;
+    private DateTime _lastPhonemeSplitClickTime = DateTime.MinValue;
+    private Point _lastPhonemeSplitClickPoint;
+    private const double PhonemeSplitDoubleClickMaxTimeMs = 350;
+    private const double PhonemeSplitDoubleClickMaxDistance = 24.0;
 
     private void OnPhonemeSplitHandlePointerPressed(object? sender, PointerPressedEventArgs e)
     {
@@ -542,11 +547,39 @@ public partial class EditorView : UserControl
             return;
         }
 
-        _phonemeSplitDragging = true;
         Point pos = e.GetPosition(this);
+
+        // 双击手柄快速折叠 / 展开
+        DateTime now = DateTime.UtcNow;
+        double elapsedMs = (now - _lastPhonemeSplitClickTime).TotalMilliseconds;
+        double dist = Math.Abs(pos.X - _lastPhonemeSplitClickPoint.X) + Math.Abs(pos.Y - _lastPhonemeSplitClickPoint.Y);
+        if (elapsedMs < PhonemeSplitDoubleClickMaxTimeMs && dist < PhonemeSplitDoubleClickMaxDistance)
+        {
+            if (vm.PianoRollViewModel.PhonemePanelHeight > 0)
+            {
+                _lastUncollapsedPhonemeHeight = vm.PianoRollViewModel.PhonemePanelHeight;
+                vm.PianoRollViewModel.PhonemePanelHeight = 0;
+            }
+            else
+            {
+                vm.PianoRollViewModel.PhonemePanelHeight = _lastUncollapsedPhonemeHeight > 30 ? _lastUncollapsedPhonemeHeight : 128.0;
+            }
+            _lastPhonemeSplitClickTime = DateTime.MinValue;
+            e.Handled = true;
+            return;
+        }
+
+        _lastPhonemeSplitClickTime = now;
+        _lastPhonemeSplitClickPoint = pos;
+
+        _phonemeSplitDragging = true;
         _phonemeSplitPressX = pos.X;
         _phonemeSplitPressY = pos.Y;
         _phonemeSplitPressHeight = vm.PianoRollViewModel.PhonemePanelHeight;
+        if (_phonemeSplitPressHeight > 30)
+        {
+            _lastUncollapsedPhonemeHeight = _phonemeSplitPressHeight;
+        }
         _phonemeSplitPressXOffset = _phonemeHandleXOffset;
         e.Pointer.Capture(PhonemeSplitHandle);
         e.Handled = true;
@@ -568,7 +601,25 @@ public partial class EditorView : UserControl
 
         Point currentPoint = e.GetPosition(this);
         double deltaY = _phonemeSplitPressY - currentPoint.Y;
-        double newHeight = Math.Clamp(_phonemeSplitPressHeight + deltaY, 36.0, 400.0);
+
+        double availableHeight = PART_PianoRollGrid.Bounds.Height > 0 ? PART_PianoRollGrid.Bounds.Height : Bounds.Height;
+        double maxPanelHeight = Math.Max(0, availableHeight - ViewConstants.PianoRollTickRulerHeight - 40.0);
+        if (maxPanelHeight <= 0)
+        {
+            maxPanelHeight = 2000.0;
+        }
+
+        double newHeight = Math.Clamp(_phonemeSplitPressHeight + deltaY, 0.0, maxPanelHeight);
+        if (newHeight < 16.0 && deltaY < 0)
+        {
+            newHeight = 0.0;
+        }
+
+        if (newHeight > 30)
+        {
+            _lastUncollapsedPhonemeHeight = newHeight;
+        }
+
         vm.PianoRollViewModel.PhonemePanelHeight = newHeight;
 
         // 水平滑动药丸手柄位置


### PR DESCRIPTION
This PR adds a collapsible phoneme and parameter panel beneath the piano roll to support editing phoneme timing, aliases, overlap, preutterance, and expression parameters. The panel has four editing modes: Simple Phoneme (timing and aliases), Advanced Phoneme (timing, preutterance, and overlap handles), Parameter Draw, and Parameter Erase.